### PR TITLE
⚙️ FEATURE-#9: Rename Where.refresh() to Where.clear_cache()

### DIFF
--- a/email_profile/searches.py
+++ b/email_profile/searches.py
@@ -57,7 +57,7 @@ class Where:
         self._cached_uids = data[0].decode().split()
         return self._cached_uids
 
-    def refresh(self) -> Where:
+    def clear_cache(self) -> Where:
         """Drop cached UIDs so the next call hits IMAP again."""
         self._cached_uids = None
         return self

--- a/tests/test_searches.py
+++ b/tests/test_searches.py
@@ -136,8 +136,8 @@ class TestUidsCache(TestCase):
         w.exists()
         self.assertEqual(len(self._search_calls()), 1)
 
-    def test_refresh_invalidates_cache(self):
+    def test_clear_cache_invalidates_cache(self):
         w = self.app.inbox.where()
         w.count()
-        w.refresh().count()
+        w.clear_cache().count()
         self.assertEqual(len(self._search_calls()), 2)


### PR DESCRIPTION
Closes #9

## Summary

Renames `Where.refresh()` to `Where.clear_cache()`. The old name suggested "fetch fresh data from the server" but the method actually just drops the local UID cache so the next call re-hits IMAP.

## Before

```python
w = inbox.where(unseen=True)
w.count()
w.refresh().count()   # ambiguous: refresh what?
```

## After

```python
w = inbox.where(unseen=True)
w.count()
w.clear_cache().count()   # explicit: drops cached UIDs
```

## Changes

- `email_profile/searches.py` — method renamed, behaviour unchanged.
- `tests/test_searches.py` — test renamed to `test_clear_cache_invalidates_cache`.

## Test plan

- [x] `pytest tests/test_searches.py` — green
- [x] `ruff check` + `ruff format --check` + `flake8` — clean