### PR TITLE
⚙️ FEATURE-#10: Add Email public properties

### DIFF
--- a/docs_src/connect_address.py
+++ b/docs_src/connect_address.py
@@ -12,7 +12,7 @@ def main() -> None:
     with Email(
         user="contato@suaempresa.com.br", password="your-password"
     ) as app:
-        print(f"Auto-discovered. Connected as {app._user}")
+        print(f"Auto-discovered. Connected as {app.user}")
         print(f"Inbox: {app.all().count()} messages")
 
 

--- a/docs_src/connect_zero_args.py
+++ b/docs_src/connect_zero_args.py
@@ -10,7 +10,7 @@ from email_profile import Email
 
 def main() -> None:
     with Email() as app:
-        print(f"Connected as {app._user}")
+        print(f"Connected as {app.user}")
         print(f"Unread: {app.unread().count()}")
 
 

--- a/email_profile/email.py
+++ b/email_profile/email.py
@@ -82,6 +82,31 @@ class Email:
         self._client: Optional[imaplib.IMAP4_SSL] = None
         self._mailboxes: dict[str, MailBox] = {}
 
+    @property
+    def server(self) -> str:
+        """The IMAP server hostname."""
+        return self._server
+
+    @property
+    def user(self) -> str:
+        """The authenticated user / email address."""
+        return self._user
+
+    @property
+    def port(self) -> int:
+        """The IMAP port in use."""
+        return self._port
+
+    @property
+    def ssl(self) -> bool:
+        """Whether the connection uses SSL."""
+        return self._ssl
+
+    @property
+    def is_connected(self) -> bool:
+        """``True`` while an IMAP session is open."""
+        return self._client is not None
+
     @staticmethod
     def _build_from_env(
         server_var: str = "EMAIL_SERVER",
@@ -384,5 +409,5 @@ class Email:
         self.close()
 
     def __repr__(self) -> str:
-        state = "connected" if self._client else "disconnected"
-        return f"Email(server={self._server!r}, user={self._user!r}, {state})"
+        state = "connected" if self.is_connected else "disconnected"
+        return f"Email(server={self.server!r}, user={self.user!r}, {state})"

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -75,8 +75,8 @@ class TestFromEmail(TestCase):
             return_value=IMAPHost("imap.test", port=993),
         ):
             app = Email.from_email("a@test.example", "pw")
-        self.assertEqual(app._server, "imap.test")
-        self.assertEqual(app._user, "a@test.example")
+        self.assertEqual(app.server, "imap.test")
+        self.assertEqual(app.user, "a@test.example")
 
 
 class TestFromEnv(TestCase):
@@ -91,7 +91,7 @@ class TestFromEnv(TestCase):
             clear=True,
         ):
             app = Email.from_env(load_dotenv=False)
-        self.assertEqual(app._server, "imap.x.com")
+        self.assertEqual(app.server, "imap.x.com")
 
     def test_auto_discovers_when_server_missing(self):
         with patch.dict(
@@ -100,7 +100,7 @@ class TestFromEnv(TestCase):
             clear=True,
         ):
             app = Email.from_env(load_dotenv=False)
-        self.assertEqual(app._server, "imap.gmail.com")
+        self.assertEqual(app.server, "imap.gmail.com")
 
     def test_missing_credentials_raises(self):
         with (
@@ -174,14 +174,36 @@ class TestQueryShortcuts(TestCase):
         self.assertTrue(any("TEXT" in str(c) for c in searches))
 
 
+class TestPublicProperties(TestCase):
+    def test_properties_expose_config(self):
+        app = Email("imap.x.com", "u", "pw", port=143, ssl=False)
+        self.assertEqual(app.server, "imap.x.com")
+        self.assertEqual(app.user, "u")
+        self.assertEqual(app.port, 143)
+        self.assertFalse(app.ssl)
+
+    def test_is_connected_false_before_connect(self):
+        app = Email("imap.x.com", "u", "pw")
+        self.assertFalse(app.is_connected)
+
+    def test_is_connected_true_after_connect(self):
+        fake = make_fake_client()
+        with (
+            patch("email_profile.email.imaplib.IMAP4_SSL", return_value=fake),
+            Email("imap.x", "u", "p") as app,
+        ):
+            self.assertTrue(app.is_connected)
+        self.assertFalse(app.is_connected)
+
+
 class TestConstructorOverloads(TestCase):
     def test_three_positional_args_explicit(self):
         app = Email("imap.x.com", "u", "pw")
-        self.assertEqual(app._server, "imap.x.com")
+        self.assertEqual(app.server, "imap.x.com")
 
     def test_keyword_form(self):
         app = Email(server="imap.x.com", user="u", password="pw")
-        self.assertEqual(app._server, "imap.x.com")
+        self.assertEqual(app.server, "imap.x.com")
 
     def test_two_args_with_email_auto_discovers(self):
         from email_profile import IMAPHost
@@ -191,8 +213,8 @@ class TestConstructorOverloads(TestCase):
             return_value=IMAPHost("imap.test"),
         ):
             app = Email("u@test.example", "pw")
-        self.assertEqual(app._server, "imap.test")
-        self.assertEqual(app._user, "u@test.example")
+        self.assertEqual(app.server, "imap.test")
+        self.assertEqual(app.user, "u@test.example")
 
     def test_zero_args_reads_env(self):
         with (
@@ -209,7 +231,7 @@ class TestConstructorOverloads(TestCase):
         ):
             build.return_value = ("imap.x.com", "u@x.com", "pw")
             app = Email()
-        self.assertEqual(app._server, "imap.x.com")
+        self.assertEqual(app.server, "imap.x.com")
 
     def test_zero_args_without_env_raises(self):
         with (


### PR DESCRIPTION
Closes #10

## Summary

Exposes `Email` configuration as read-only public properties so external code stops reading underscored private attributes.

## New properties

| Property | Returns |
|---|---|
| `app.server` | IMAP host |
| `app.user` | Authenticated user / email |
| `app.port` | IMAP port |
| `app.ssl` | Whether the connection uses SSL |
| `app.is_connected` | `True` while an IMAP session is open |

## Side updates

- `Email.__repr__` now uses the public properties instead of `self._server` / `self._user`.
- `docs_src/connect_address.py`, `docs_src/connect_zero_args.py` — switched from `app._user` to `app.user`.
- `tests/test_email.py` — same migration, plus new `TestPublicProperties` class covering all five properties (including connection state transitions).

## Test plan

- [x] `pytest tests/` — 134 passed
- [x] `ruff check` + `ruff format --check` + `flake8` — clean