### PR TITLE
⚙️ FEATURE-#8: Remove MessageDumper from public __all__

### DIFF
--- a/email_profile/__init__.py
+++ b/email_profile/__init__.py
@@ -23,7 +23,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE."""
 
-from email_profile.dump import MessageDumper
 from email_profile.email import Email
 from email_profile.eml import EmailModel, EmailSerializer
 from email_profile.errors import (
@@ -57,7 +56,6 @@ __all__ = [
     "IMAPError",
     "IMAPHost",
     "MailBox",
-    "MessageDumper",
     "NotConnected",
     "ParsedBody",
     "ProviderResolutionError",

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -2,7 +2,8 @@ import tempfile
 from pathlib import Path
 from unittest import TestCase
 
-from email_profile import EmailSerializer, MessageDumper
+from email_profile import EmailSerializer
+from email_profile.dump import MessageDumper
 from tests.conftest import SAMPLE_RFC822
 
 


### PR DESCRIPTION
Closes #8

## Summary

Removes `MessageDumper` from `email_profile.__all__`. The canonical way to dump messages to disk is now `msg.save_json()` / `msg.save_html()` / `msg.save_attachments()`.

`MessageDumper` remains importable from `email_profile.dump` for advanced users who want to build custom dumpers.

## Changes

- `email_profile/__init__.py` — `MessageDumper` removed from imports and `__all__`.
- `tests/test_dump.py` — import moved to `email_profile.dump`.

## Test plan

- [x] 131 tests pass
- [x] ruff clean