### PR TITLE
⚙️ FEATURE-#11: Move AppendedUID and IMAPHost to email_profile.types

### DIFF
--- a/email_profile/mailbox.py
+++ b/email_profile/mailbox.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import imaplib
 import re
 import time
-from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -13,20 +12,13 @@ from email_profile._internal import _state
 from email_profile.query import Query, QueryLike
 from email_profile.retry import with_retry
 from email_profile.searches import Where
+from email_profile.types import AppendedUID
 
 if TYPE_CHECKING:
     from email_profile.eml import EmailSerializer
 
 
 MessageLike = Union["EmailSerializer", bytes, str]
-
-
-@dataclass(frozen=True)
-class AppendedUID:
-    """Result of a successful IMAP APPEND when the server supports UIDPLUS."""
-
-    uidvalidity: int
-    uid: int
 
 
 _APPENDUID_RE = re.compile(rb"APPENDUID (\d+) (\d+)")

--- a/email_profile/providers.py
+++ b/email_profile/providers.py
@@ -12,8 +12,9 @@ Resolution strategy, in order:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Optional
+
+from email_profile.types import IMAPHost
 
 try:
     import dns.resolver
@@ -26,13 +27,6 @@ except ImportError:
 
 class ProviderResolutionError(RuntimeError):
     """Raised when no IMAP host can be discovered for an address."""
-
-
-@dataclass(frozen=True)
-class IMAPHost:
-    host: str
-    port: int = 993
-    ssl: bool = True
 
 
 KNOWN_PROVIDERS: dict[str, IMAPHost] = {

--- a/email_profile/types.py
+++ b/email_profile/types.py
@@ -1,0 +1,22 @@
+"""Public value types used across the package."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class IMAPHost:
+    """The IMAP host + port + ssl flag for an account."""
+
+    host: str
+    port: int = 993
+    ssl: bool = True
+
+
+@dataclass(frozen=True)
+class AppendedUID:
+    """Result of a successful IMAP APPEND when the server supports UIDPLUS."""
+
+    uidvalidity: int
+    uid: int


### PR DESCRIPTION
Closes #11

## Summary

Both `AppendedUID` and `IMAPHost` are return-type value objects that the user rarely instantiates directly. Moving them to a dedicated `email_profile/types.py` module makes their role explicit and keeps `mailbox.py` / `providers.py` focused on behaviour.

## Backwards compatibility

Existing imports keep working — `mailbox.py` and `providers.py` re-export the symbols:

```python
from email_profile.mailbox import AppendedUID   # still works
from email_profile.providers import IMAPHost    # still works
from email_profile.types import AppendedUID, IMAPHost   # new canonical location
```

## Changes

- `email_profile/types.py` (new) — holds the two frozen dataclasses.
- `email_profile/mailbox.py` — imports `AppendedUID` from `types`; definition removed locally.
- `email_profile/providers.py` — imports `IMAPHost` from `types`; definition removed locally.

## Test plan

- [x] 131 tests pass
- [x] ruff + format clean