### PR TITLE
⚙️ FEATURE-#18: Add SMTP send + split Email into 6 classes

### DIFF
--- a/docs_src/README.md
+++ b/docs_src/README.md
@@ -53,6 +53,14 @@ in a `.env` file at the repo root.
 | [headers_bag.py](headers_bag.py) | Inspect non-standard `X-*` headers |
 | [threads.py](threads.py) | Reconstruct conversation threads |
 
+## Sending mail (SMTP)
+
+| File | What it shows |
+|------|---------------|
+| [send_email.py](send_email.py) | `app.send(to=, subject=, body=, ...)` with auto-discovered SMTP |
+| [reply_email.py](reply_email.py) | `app.reply(msg, body=...)` preserving threading |
+| [forward_email.py](forward_email.py) | `app.forward(msg, to=...)` with quoted body |
+
 ## Backup, restore, migration
 
 | File | What it shows |

--- a/docs_src/forward_email.py
+++ b/docs_src/forward_email.py
@@ -1,0 +1,22 @@
+"""Forward a message to another recipient."""
+
+from email_profile import Email
+
+
+def main() -> None:
+    with Email(user="you@yourdomain.com", password="your-password") as app:
+        msg = next(app.recent(days=1).messages(), None)
+        if msg is None:
+            print("Nothing recent to forward.")
+            return
+
+        app.forward(
+            msg,
+            to="colleague@example.com",
+            body="FYI — heads up on this one.",
+        )
+        print(f"Forwarded: {msg.subject}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs_src/reply_email.py
+++ b/docs_src/reply_email.py
@@ -1,0 +1,22 @@
+"""Reply to a message — preserves `In-Reply-To` and `References`."""
+
+from email_profile import Email
+
+
+def main() -> None:
+    with Email(user="you@yourdomain.com", password="your-password") as app:
+        original = next(app.inbox.where(subject="invoice").messages(), None)
+        if original is None:
+            print("Nothing to reply to.")
+            return
+
+        app.reply(
+            original,
+            body="Thanks — processing now.",
+            reply_all=False,
+        )
+        print(f"Replied to: {original.subject}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs_src/send_email.py
+++ b/docs_src/send_email.py
@@ -1,0 +1,26 @@
+"""Send an email via SMTP.
+
+The SMTP host is auto-discovered from the user's domain (same way as IMAP).
+By default the message is also appended to the Sent folder so it shows up
+in the account history on providers that don't auto-save outgoing mail
+(Hostinger, cPanel, etc.).
+"""
+
+from email_profile import Email
+
+
+def main() -> None:
+    with Email(user="you@yourdomain.com", password="your-password") as app:
+        app.send(
+            to="bob@example.com",
+            subject="Hello from email-profile",
+            body="This was sent via SMTP auto-discovery.",
+            html="<p>This was sent via <b>SMTP</b> auto-discovery.</p>",
+            attachments=["./report.pdf"],
+            cc=["alice@example.com"],
+        )
+        print("Sent.")
+
+
+if __name__ == "__main__":
+    main()

--- a/email_profile/__init__.py
+++ b/email_profile/__init__.py
@@ -42,12 +42,15 @@ from email_profile.providers import (
     IMAPHost,
     ProviderResolutionError,
     resolve_imap_host,
+    resolve_smtp_host,
 )
 from email_profile.query import Q, Query
 from email_profile.retry import with_retry
 from email_profile.searches import Where
+from email_profile.smtp import SmtpClient
 from email_profile.status import IMAPError, Status
 from email_profile.storage import Storage
+from email_profile.types import SMTPHost
 
 __all__ = [
     "ConnectionFailure",

--- a/email_profile/advanced.py
+++ b/email_profile/advanced.py
@@ -19,10 +19,13 @@ from email_profile.providers import (
     IMAPHost,
     ProviderResolutionError,
     resolve_imap_host,
+    resolve_smtp_host,
 )
 from email_profile.retry import with_retry
 from email_profile.searches import Where
+from email_profile.smtp import SmtpClient
 from email_profile.status import IMAPError, Status
+from email_profile.types import SMTPHost
 
 __all__ = [
     "AppendedUID",
@@ -35,10 +38,13 @@ __all__ = [
     "ParsedBody",
     "ProviderResolutionError",
     "Retryable",
+    "SMTPHost",
+    "SmtpClient",
     "Status",
     "StorageProtocol",
     "Where",
     "parse_rfc822",
     "resolve_imap_host",
+    "resolve_smtp_host",
     "with_retry",
 ]

--- a/email_profile/backup.py
+++ b/email_profile/backup.py
@@ -1,0 +1,112 @@
+"""Restore operations: re-upload a backup to the server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Union
+
+from email_profile.imap_session import IMAPSession
+
+if TYPE_CHECKING:
+    from email_profile.protocols import StorageProtocol
+
+
+class RestoreOps:
+    """Idempotent restore of persisted messages back to an IMAP server."""
+
+    def __init__(self, session: IMAPSession) -> None:
+        self._session = session
+
+    def restore(
+        self,
+        storage: StorageProtocol,
+        mailbox: Optional[str] = None,
+        target: Optional[str] = None,
+        skip_duplicates: bool = True,
+    ) -> int:
+        """Re-upload every message persisted in storage to this server."""
+        self._session.require()
+        count = 0
+        seen_ids: dict[str, set[str]] = {}
+
+        for serializer in storage.messages(mailbox=mailbox):
+            box_name = target or serializer.mailbox
+            if box_name not in self._session.mailboxes:
+                raise KeyError(
+                    f"Target mailbox {box_name!r} does not exist. "
+                    f"Available: {list(self._session.mailboxes)}"
+                )
+
+            if skip_duplicates:
+                if box_name not in seen_ids:
+                    seen_ids[box_name] = self._existing_ids(box_name)
+                if serializer.id and serializer.id in seen_ids[box_name]:
+                    continue
+                if serializer.id:
+                    seen_ids[box_name].add(serializer.id)
+
+            self._session.mailboxes[box_name].append(serializer)
+            count += 1
+
+        return count
+
+    def restore_eml(
+        self,
+        path: Union[str, Path],
+        target: Optional[str] = None,
+    ) -> int:
+        """Re-upload every .eml under path; mailbox = parent dir name."""
+        self._session.require()
+        source = Path(path)
+        if not source.exists():
+            raise FileNotFoundError(source)
+
+        count = 0
+        for eml_path in source.rglob("*.eml"):
+            box_name = target or eml_path.parent.name
+            if box_name not in self._session.mailboxes:
+                raise KeyError(
+                    f"Target mailbox {box_name!r} does not exist. "
+                    f"Available: {list(self._session.mailboxes)}"
+                )
+            self._session.mailboxes[box_name].append(eml_path.read_bytes())
+            count += 1
+
+        return count
+
+    def _existing_ids(self, mailbox_name: str) -> set[str]:
+        """Collect Message-IDs already present in a server mailbox."""
+        from email_profile._internal import _state
+
+        ids: set[str] = set()
+        client = self._session.client
+        if client is None:
+            return ids
+
+        _state(client.select(mailbox_name))
+        status, data = client.uid("search", None, "ALL")
+        if status != "OK" or not data or not data[0]:
+            return ids
+
+        uids = data[0].decode().split()
+        if not uids:
+            return ids
+
+        status, fetched = client.uid(
+            "fetch",
+            ",".join(uids),
+            "(BODY.PEEK[HEADER.FIELDS (MESSAGE-ID)])",
+        )
+        if status != "OK":
+            return ids
+
+        for entry in fetched:
+            if not isinstance(entry, tuple):
+                continue
+            _, raw = entry
+            text = raw.decode("utf-8", errors="replace")
+            for line in text.splitlines():
+                if line.lower().startswith("message-id:"):
+                    ids.add(line.split(":", 1)[1].strip())
+                    break
+        return ids

--- a/email_profile/email.py
+++ b/email_profile/email.py
@@ -2,33 +2,30 @@
 
 from __future__ import annotations
 
-import imaplib
-import os
-from datetime import date, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
 
-from email_profile._internal import _state
-from email_profile.errors import ConnectionFailure, NotConnected
-from email_profile.folders import (
-    ARCHIVE_HINTS,
-    DRAFTS_HINTS,
-    INBOX_HINTS,
-    SENT_HINTS,
-    SPAM_HINTS,
-    TRASH_HINTS,
-    find_mailbox,
-)
-from email_profile.mailbox import MailBox
-from email_profile.providers import IMAPHost, resolve_imap_host
+from email_profile.backup import RestoreOps
+from email_profile.factories import Credentials, EmailFactories
+from email_profile.folders import FolderAccess
+from email_profile.imap_session import IMAPSession
+from email_profile.providers import resolve_imap_host
+from email_profile.queries import QueryShortcuts
 from email_profile.searches import Where
+from email_profile.sender import Sender
+from email_profile.smtp import AttachmentLike
 
 if TYPE_CHECKING:
+    from email.message import EmailMessage
+
+    from email_profile.eml import EmailSerializer
+    from email_profile.mailbox import MailBox
     from email_profile.protocols import StorageProtocol
+    from email_profile.types import SMTPHost
 
 
 class Email:
-    """IMAP client; lazy connect via ``with Email(...) as app:``.
+    """IMAP + SMTP client. Lazy connect via ``with Email(...) as app:``.
 
     Constructor overloads::
 
@@ -37,8 +34,6 @@ class Email:
         Email("imap.gmail.com", "u", "pw")                  # explicit host
         Email(server="...", user="...", password="...")     # full kwargs
         Email()                                              # zero args -> env
-
-    The ``Email.gmail/.../from_env`` classmethods keep working.
     """
 
     def __init__(
@@ -49,23 +44,36 @@ class Email:
         port: int = 993,
         ssl: bool = True,
     ) -> None:
+        creds = self._resolve(server, user, password, port, ssl)
+
+        self._session = IMAPSession(
+            server=creds.server,
+            user=creds.user,
+            password=creds.password,
+            port=creds.port,
+            ssl=creds.ssl,
+        )
+        self._folders = FolderAccess(self._session)
+        self._queries = QueryShortcuts(self._folders)
+        self._backup = RestoreOps(self._session)
+        self._sender = Sender(self._session, self._folders)
+
+    @staticmethod
+    def _resolve(
+        server: Optional[str],
+        user: Optional[str],
+        password: Optional[str],
+        port: int,
+        ssl: bool,
+    ) -> Credentials:
         if server is None and user is None and password is None:
-            built = Email._build_from_env()
-            self._server, self._user, self._password = built
-            self._port, self._ssl = 993, True
-            self._client = None
-            self._mailboxes = {}
-            return
+            return EmailFactories.from_env()
 
         if password is None and user is not None and server and "@" in server:
-            address, password = server, user
-            host: IMAPHost = resolve_imap_host(address)
-            server, user = host.host, address
-            port, ssl = host.port, host.ssl
+            return EmailFactories.from_address(server, user)
 
         if server is None and user is not None and "@" in user and password:
-            host = resolve_imap_host(user)
-            server, port, ssl = host.host, host.port, host.ssl
+            return EmailFactories.from_address(user, password)
 
         if server is None or user is None or password is None:
             raise TypeError(
@@ -74,74 +82,34 @@ class Email:
                 "or no args (env vars)."
             )
 
-        self._server = server
-        self._user = user
-        self._password = password
-        self._port = port
-        self._ssl = ssl
-        self._client: Optional[imaplib.IMAP4_SSL] = None
-        self._mailboxes: dict[str, MailBox] = {}
+        return Credentials(
+            server=server, user=user, password=password, port=port, ssl=ssl
+        )
 
     @property
     def server(self) -> str:
-        """The IMAP server hostname."""
-        return self._server
+        return self._session.server
 
     @property
     def user(self) -> str:
-        """The authenticated user / email address."""
-        return self._user
+        return self._session.user
 
     @property
     def port(self) -> int:
-        """The IMAP port in use."""
-        return self._port
+        return self._session.port
 
     @property
     def ssl(self) -> bool:
-        """Whether the connection uses SSL."""
-        return self._ssl
+        return self._session.ssl
 
     @property
     def is_connected(self) -> bool:
-        """``True`` while an IMAP session is open."""
-        return self._client is not None
-
-    @staticmethod
-    def _build_from_env(
-        server_var: str = "EMAIL_SERVER",
-        user_var: str = "EMAIL_USERNAME",
-        password_var: str = "EMAIL_PASSWORD",
-        load_dotenv: bool = True,
-    ) -> tuple[str, str, str]:
-        if load_dotenv:
-            try:
-                from dotenv import load_dotenv as _ld
-
-                _ld()
-            except ImportError:
-                pass
-
-        user = os.environ.get(user_var)
-        password = os.environ.get(password_var)
-
-        if not user or not password:
-            raise KeyError(
-                f"Missing {user_var!r} or {password_var!r} in environment."
-            )
-
-        server = os.environ.get(server_var)
-        if not server:
-            host = resolve_imap_host(user)
-            server = host.host
-        return server, user, password
+        return self._session.is_connected
 
     @classmethod
     def from_email(cls, address: str, password: str) -> Email:
         """Auto-discover the IMAP host from the address."""
-
-        host: IMAPHost = resolve_imap_host(address)
-
+        host = resolve_imap_host(address)
         return cls(
             server=host.host,
             user=address,
@@ -159,13 +127,15 @@ class Email:
         load_dotenv: bool = True,
     ) -> Email:
         """Read credentials from env or .env; auto-discover if missing."""
-        server, user, password = cls._build_from_env(
+        creds = EmailFactories.from_env(
             server_var=server_var,
             user_var=user_var,
             password_var=password_var,
             load_dotenv=load_dotenv,
         )
-        return cls(server=server, user=user, password=password)
+        return cls(
+            server=creds.server, user=creds.user, password=creds.password
+        )
 
     @classmethod
     def gmail(cls, user: str, password: str) -> Email:
@@ -196,106 +166,56 @@ class Email:
         return cls("imap.fastmail.com", user, password)
 
     def connect(self) -> Email:
-        """Open the IMAP connection and discover mailboxes."""
-        try:
-            client = imaplib.IMAP4_SSL(self._server)
-            client.login(user=self._user, password=self._password)
-        except Exception as error:
-            raise ConnectionFailure() from error
-
-        self._client = client
-
-        self._mailboxes = {
-            mb.name: mb
-            for mb in (
-                MailBox.from_imap_detail(client=client, detail=detail)
-                for detail in _state(client.list())
-            )
-        }
-
+        self._session.connect()
         return self
 
     def close(self) -> None:
-        """Close the IMAP connection; safe to call twice."""
-        if self._client is not None:
-            try:
-                self._client.logout()
-            finally:
-                self._client = None
-                self._mailboxes = {}
+        self._session.close()
 
     def noop(self) -> None:
-        """Send IMAP NOOP to keep the connection alive on long jobs."""
-        self._require_connection()
-        self._client.noop()
+        self._session.noop()
 
     def mailboxes(self) -> list[str]:
-        """All mailbox names visible on the server."""
-        self._require_connection()
-        return list(self._mailboxes)
+        return self._folders.mailboxes()
 
     def mailbox(self, name: str) -> MailBox:
-        """One mailbox by its server-side name."""
-        self._require_connection()
-
-        if name not in self._mailboxes:
-            raise KeyError(
-                f"Unknown mailbox: {name!r}. Available: {self.mailboxes()}"
-            )
-
-        return self._mailboxes[name]
-
-    def _find(self, hints: tuple[str, ...]) -> MailBox:
-        self._require_connection()
-        mb = find_mailbox(self._mailboxes, hints)
-
-        if mb is None:
-            raise KeyError(
-                f"Could not find a mailbox matching {hints!r}. "
-                f"Available: {self.mailboxes()}"
-            )
-
-        return mb
+        return self._folders.mailbox(name)
 
     @property
     def inbox(self) -> MailBox:
-        return self._find(INBOX_HINTS)
+        return self._folders.inbox
 
     @property
     def sent(self) -> MailBox:
-        return self._find(SENT_HINTS)
+        return self._folders.sent
 
     @property
     def spam(self) -> MailBox:
-        return self._find(SPAM_HINTS)
+        return self._folders.spam
 
     @property
     def trash(self) -> MailBox:
-        return self._find(TRASH_HINTS)
+        return self._folders.trash
 
     @property
     def drafts(self) -> MailBox:
-        return self._find(DRAFTS_HINTS)
+        return self._folders.drafts
 
     @property
     def archive(self) -> MailBox:
-        return self._find(ARCHIVE_HINTS)
+        return self._folders.archive
 
     def unread(self) -> Where:
-        """Unread messages in the inbox."""
-        return self.inbox.where(unseen=True)
+        return self._queries.unread()
 
     def recent(self, days: int = 7) -> Where:
-        """Messages from the last N days."""
-        return self.inbox.where(since=date.today() - timedelta(days=days))
+        return self._queries.recent(days)
 
     def search(self, text: str) -> Where:
-        """Full-text search in the inbox."""
-        return self.inbox.where(text=text)
+        return self._queries.search(text)
 
     def all(self) -> Where:
-        """All messages in the inbox."""
-        return self.inbox.where()
+        return self._queries.all()
 
     def restore(
         self,
@@ -304,102 +224,93 @@ class Email:
         target: Optional[str] = None,
         skip_duplicates: bool = True,
     ) -> int:
-        """Re-upload every message persisted in storage to this server.
-
-        With ``skip_duplicates=True`` (default) any message whose
-        ``Message-ID`` already exists in the destination mailbox is
-        skipped — making ``restore`` safe to re-run after an interruption.
-        """
-
-        self._require_connection()
-        count = 0
-        seen_ids: dict[str, set[str]] = {}
-
-        for serializer in storage.messages(mailbox=mailbox):
-            box_name = target or serializer.mailbox
-            if box_name not in self._mailboxes:
-                raise KeyError(
-                    f"Target mailbox {box_name!r} does not exist. "
-                    f"Available: {self.mailboxes()}"
-                )
-
-            if skip_duplicates:
-                if box_name not in seen_ids:
-                    seen_ids[box_name] = self._existing_ids(box_name)
-                if serializer.id and serializer.id in seen_ids[box_name]:
-                    continue
-                if serializer.id:
-                    seen_ids[box_name].add(serializer.id)
-
-            self._mailboxes[box_name].append(serializer)
-            count += 1
-
-        return count
+        return self._backup.restore(
+            storage=storage,
+            mailbox=mailbox,
+            target=target,
+            skip_duplicates=skip_duplicates,
+        )
 
     def restore_eml(
         self,
         path: Union[str, Path],
         target: Optional[str] = None,
     ) -> int:
-        """Re-upload every .eml under path; mailbox = parent dir name."""
+        return self._backup.restore_eml(path=path, target=target)
 
-        self._require_connection()
-        source = Path(path)
-        if not source.exists():
-            raise FileNotFoundError(source)
+    def smtp_host(self) -> SMTPHost:
+        return self._sender.smtp_host()
 
-        count = 0
-
-        for eml_path in source.rglob("*.eml"):
-            box_name = target or eml_path.parent.name
-            if box_name not in self._mailboxes:
-                raise KeyError(
-                    f"Target mailbox {box_name!r} does not exist. "
-                    f"Available: {self.mailboxes()}"
-                )
-            self._mailboxes[box_name].append(eml_path.read_bytes())
-            count += 1
-
-        return count
-
-    def _existing_ids(self, mailbox_name: str) -> set[str]:
-        """Collect Message-IDs already present in a server mailbox."""
-        from email_profile._internal import _state
-
-        ids: set[str] = set()
-        client = self._client
-        if client is None:
-            return ids
-
-        _state(client.select(mailbox_name))
-        status, data = client.uid("search", None, "ALL")
-        if status != "OK" or not data or not data[0]:
-            return ids
-
-        uids = data[0].decode().split()
-        if not uids:
-            return ids
-
-        status, fetched = client.uid(
-            "fetch", ",".join(uids), "(BODY.PEEK[HEADER.FIELDS (MESSAGE-ID)])"
+    def send(
+        self,
+        to: Union[str, list[str]],
+        subject: str,
+        body: str = "",
+        *,
+        html: Optional[str] = None,
+        cc: Optional[Union[str, list[str]]] = None,
+        bcc: Optional[Union[str, list[str]]] = None,
+        reply_to: Optional[str] = None,
+        attachments: Optional[list[AttachmentLike]] = None,
+        headers: Optional[dict[str, str]] = None,
+        save_to_sent: bool = True,
+    ) -> None:
+        self._sender.send(
+            to=to,
+            subject=subject,
+            body=body,
+            html=html,
+            cc=cc,
+            bcc=bcc,
+            reply_to=reply_to,
+            attachments=attachments,
+            headers=headers,
+            save_to_sent=save_to_sent,
         )
-        if status != "OK":
-            return ids
 
-        for entry in fetched:
-            if not isinstance(entry, tuple):
-                continue
-            _, raw = entry
-            text = raw.decode("utf-8", errors="replace")
-            for line in text.splitlines():
-                if line.lower().startswith("message-id:"):
-                    ids.add(line.split(":", 1)[1].strip())
-                    break
-        return ids
+    def send_message(
+        self,
+        message: EmailMessage,
+        *,
+        save_to_sent: bool = True,
+    ) -> None:
+        self._sender.send_message(message, save_to_sent=save_to_sent)
 
-    def _require_connection(self) -> None:
-        if self._client is None:
-            raise NotConnected()
+    def reply(
+        self,
+        original: EmailSerializer,
+        body: str = "",
+        *,
+        html: Optional[str] = None,
+        attachments: Optional[list[AttachmentLike]] = None,
+        reply_all: bool = False,
+        save_to_sent: bool = True,
+    ) -> None:
+        self._sender.reply(
+            original=original,
+            body=body,
+            html=html,
+            attachments=attachments,
+            reply_all=reply_all,
+            save_to_sent=save_to_sent,
+        )
+
+    def forward(
+        self,
+        original: EmailSerializer,
+        to: Union[str, list[str]],
+        body: str = "",
+        *,
+        attachments: Optional[list[AttachmentLike]] = None,
+        save_to_sent: bool = True,
+    ) -> None:
+        self._sender.forward(
+            original=original,
+            to=to,
+            body=body,
+            attachments=attachments,
+            save_to_sent=save_to_sent,
+        )
 
     def __enter__(self) -> Email:
         return self.connect()

--- a/email_profile/factories.py
+++ b/email_profile/factories.py
@@ -1,0 +1,90 @@
+"""Connection-building helpers: from env, from email, per-provider hosts."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from email_profile.providers import resolve_imap_host
+
+
+@dataclass(frozen=True)
+class Credentials:
+    """Resolved (server, user, password, port, ssl) tuple."""
+
+    server: str
+    user: str
+    password: str
+    port: int = 993
+    ssl: bool = True
+
+
+class EmailFactories:
+    """Ways to build :class:`Credentials` without the user spelling out
+    an IMAP hostname."""
+
+    PROVIDER_HOSTS: dict[str, str] = {
+        "gmail": "imap.gmail.com",
+        "outlook": "outlook.office365.com",
+        "icloud": "imap.mail.me.com",
+        "yahoo": "imap.mail.yahoo.com",
+        "hostinger": "imap.hostinger.com",
+        "zoho": "imap.zoho.com",
+        "fastmail": "imap.fastmail.com",
+    }
+
+    @classmethod
+    def from_address(cls, address: str, password: str) -> Credentials:
+        """Auto-discover the IMAP host from the email address."""
+        host = resolve_imap_host(address)
+        return Credentials(
+            server=host.host,
+            user=address,
+            password=password,
+            port=host.port,
+            ssl=host.ssl,
+        )
+
+    @classmethod
+    def from_env(
+        cls,
+        server_var: str = "EMAIL_SERVER",
+        user_var: str = "EMAIL_USERNAME",
+        password_var: str = "EMAIL_PASSWORD",
+        load_dotenv: bool = True,
+    ) -> Credentials:
+        """Read credentials from env vars (or `.env`)."""
+        if load_dotenv:
+            try:
+                from dotenv import load_dotenv as _ld
+
+                _ld()
+            except ImportError:
+                pass
+
+        user = os.environ.get(user_var)
+        password = os.environ.get(password_var)
+        if not user or not password:
+            raise KeyError(
+                f"Missing {user_var!r} or {password_var!r} in environment."
+            )
+
+        server = os.environ.get(server_var)
+        if server:
+            return Credentials(server=server, user=user, password=password)
+
+        return cls.from_address(user, password)
+
+    @classmethod
+    def from_provider(
+        cls, provider: str, user: str, password: str
+    ) -> Credentials:
+        """Build credentials for a well-known provider by short name."""
+        key = provider.lower()
+        host = cls.PROVIDER_HOSTS.get(key)
+        if host is None:
+            raise KeyError(
+                f"Unknown provider {provider!r}. "
+                f"Known: {sorted(cls.PROVIDER_HOSTS)}"
+            )
+        return Credentials(server=host, user=user, password=password)

--- a/email_profile/folders.py
+++ b/email_profile/folders.py
@@ -1,10 +1,11 @@
-"""Mailbox name hints (EN/PT/ES) and the matching helper."""
+"""Mailbox name hints (EN/PT/ES), matching helper, and FolderAccess class."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
+    from email_profile.imap_session import IMAPSession
     from email_profile.mailbox import MailBox
 
 
@@ -82,3 +83,56 @@ def find_mailbox(
                 return mb
 
     return None
+
+
+class FolderAccess:
+    """Resolve common folder properties (inbox/sent/spam/...) for a session."""
+
+    def __init__(self, session: IMAPSession) -> None:
+        self._session = session
+
+    def mailboxes(self) -> list[str]:
+        self._session.require()
+        return list(self._session.mailboxes)
+
+    def mailbox(self, name: str) -> MailBox:
+        self._session.require()
+        if name not in self._session.mailboxes:
+            raise KeyError(
+                f"Unknown mailbox: {name!r}. Available: {self.mailboxes()}"
+            )
+        return self._session.mailboxes[name]
+
+    def _find(self, hints: tuple[str, ...]) -> MailBox:
+        self._session.require()
+        mb = find_mailbox(self._session.mailboxes, hints)
+        if mb is None:
+            raise KeyError(
+                f"Could not find a mailbox matching {hints!r}. "
+                f"Available: {self.mailboxes()}"
+            )
+        return mb
+
+    @property
+    def inbox(self) -> MailBox:
+        return self._find(INBOX_HINTS)
+
+    @property
+    def sent(self) -> MailBox:
+        return self._find(SENT_HINTS)
+
+    @property
+    def spam(self) -> MailBox:
+        return self._find(SPAM_HINTS)
+
+    @property
+    def trash(self) -> MailBox:
+        return self._find(TRASH_HINTS)
+
+    @property
+    def drafts(self) -> MailBox:
+        return self._find(DRAFTS_HINTS)
+
+    @property
+    def archive(self) -> MailBox:
+        return self._find(ARCHIVE_HINTS)

--- a/email_profile/imap_session.py
+++ b/email_profile/imap_session.py
@@ -1,0 +1,67 @@
+"""IMAP session lifecycle: connect, close, noop."""
+
+from __future__ import annotations
+
+import imaplib
+from typing import Optional
+
+from email_profile._internal import _state
+from email_profile.errors import ConnectionFailure, NotConnected
+from email_profile.mailbox import MailBox
+
+
+class IMAPSession:
+    """Owns the IMAP socket and the discovered mailbox map."""
+
+    def __init__(
+        self,
+        server: str,
+        user: str,
+        password: str,
+        port: int = 993,
+        ssl: bool = True,
+    ) -> None:
+        self.server = server
+        self.user = user
+        self.password = password
+        self.port = port
+        self.ssl = ssl
+        self.client: Optional[imaplib.IMAP4_SSL] = None
+        self.mailboxes: dict[str, MailBox] = {}
+
+    @property
+    def is_connected(self) -> bool:
+        return self.client is not None
+
+    def connect(self) -> IMAPSession:
+        try:
+            client = imaplib.IMAP4_SSL(self.server)
+            client.login(user=self.user, password=self.password)
+        except Exception as error:
+            raise ConnectionFailure() from error
+
+        self.client = client
+        self.mailboxes = {
+            mb.name: mb
+            for mb in (
+                MailBox.from_imap_detail(client=client, detail=detail)
+                for detail in _state(client.list())
+            )
+        }
+        return self
+
+    def close(self) -> None:
+        if self.client is not None:
+            try:
+                self.client.logout()
+            finally:
+                self.client = None
+                self.mailboxes = {}
+
+    def noop(self) -> None:
+        self.require()
+        self.client.noop()
+
+    def require(self) -> None:
+        if self.client is None:
+            raise NotConnected()

--- a/email_profile/providers.py
+++ b/email_profile/providers.py
@@ -1,20 +1,20 @@
-"""IMAP server discovery for arbitrary email addresses.
+"""IMAP and SMTP server discovery for arbitrary email addresses.
 
 Resolution strategy, in order:
 
 1. Hard-coded map of well-known providers (Gmail, Outlook, iCloud, Yahoo,
    Hostinger, Zoho, etc.).
-2. RFC 6186 SRV record lookup — ``_imaps._tcp.<domain>``.
-3. MX record lookup — infer the IMAP host from the mail exchanger
+2. RFC 6186 SRV lookup — ``_imaps._tcp.<d>`` / ``_submission._tcp.<d>``.
+3. MX record lookup — infer the host from the mail exchanger
    (e.g. ``mx1.hostinger.com`` → ``imap.hostinger.com``).
-4. Convention fallback — ``imap.<domain>`` on port 993.
+4. Convention fallback — ``imap.<domain>`` / ``smtp.<domain>``.
 """
 
 from __future__ import annotations
 
 from typing import Optional
 
-from email_profile.types import IMAPHost
+from email_profile.types import IMAPHost, SMTPHost
 
 try:
     import dns.resolver
@@ -130,3 +130,123 @@ def resolve_imap_host(address: str) -> IMAPHost:
         return mx
 
     return IMAPHost(host=f"imap.{domain}")
+
+
+KNOWN_SMTP_PROVIDERS: dict[str, SMTPHost] = {
+    "gmail.com": SMTPHost("smtp.gmail.com"),
+    "googlemail.com": SMTPHost("smtp.gmail.com"),
+    "outlook.com": SMTPHost(
+        "smtp.office365.com", port=587, ssl=False, starttls=True
+    ),
+    "hotmail.com": SMTPHost(
+        "smtp.office365.com", port=587, ssl=False, starttls=True
+    ),
+    "live.com": SMTPHost(
+        "smtp.office365.com", port=587, ssl=False, starttls=True
+    ),
+    "msn.com": SMTPHost(
+        "smtp.office365.com", port=587, ssl=False, starttls=True
+    ),
+    "office365.com": SMTPHost(
+        "smtp.office365.com", port=587, ssl=False, starttls=True
+    ),
+    "icloud.com": SMTPHost(
+        "smtp.mail.me.com", port=587, ssl=False, starttls=True
+    ),
+    "me.com": SMTPHost("smtp.mail.me.com", port=587, ssl=False, starttls=True),
+    "mac.com": SMTPHost(
+        "smtp.mail.me.com", port=587, ssl=False, starttls=True
+    ),
+    "yahoo.com": SMTPHost("smtp.mail.yahoo.com"),
+    "ymail.com": SMTPHost("smtp.mail.yahoo.com"),
+    "zoho.com": SMTPHost("smtp.zoho.com"),
+    "hostinger.com": SMTPHost("smtp.hostinger.com"),
+    "fastmail.com": SMTPHost("smtp.fastmail.com"),
+    "aol.com": SMTPHost("smtp.aol.com"),
+}
+
+
+SMTP_MX_HINTS: list[tuple[str, SMTPHost]] = [
+    ("hostinger", SMTPHost("smtp.hostinger.com")),
+    ("google.com", SMTPHost("smtp.gmail.com")),
+    ("googlemail", SMTPHost("smtp.gmail.com")),
+    (
+        "outlook.com",
+        SMTPHost("smtp.office365.com", port=587, ssl=False, starttls=True),
+    ),
+    (
+        "office365",
+        SMTPHost("smtp.office365.com", port=587, ssl=False, starttls=True),
+    ),
+    (
+        "protection.outlook.com",
+        SMTPHost("smtp.office365.com", port=587, ssl=False, starttls=True),
+    ),
+    ("zoho", SMTPHost("smtp.zoho.com")),
+    ("yahoodns", SMTPHost("smtp.mail.yahoo.com")),
+    ("yandex", SMTPHost("smtp.yandex.com")),
+    ("mail.ru", SMTPHost("smtp.mail.ru")),
+    ("locaweb", SMTPHost("smtp.locaweb.com.br")),
+    ("kinghost", SMTPHost("smtp.kinghost.net")),
+    ("uol.com", SMTPHost("smtp.uol.com.br")),
+    ("fastmail", SMTPHost("smtp.fastmail.com")),
+]
+
+
+def _lookup_smtp_srv(domain: str) -> Optional[SMTPHost]:
+    if not _HAS_DNS:
+        return None
+    try:
+        answers = dns.resolver.resolve(
+            f"_submission._tcp.{domain}", "SRV", lifetime=3.0
+        )
+    except DNSException:
+        return None
+    for rdata in sorted(answers, key=lambda r: (r.priority, -r.weight)):
+        host = str(rdata.target).rstrip(".")
+        if host and host != ".":
+            port = int(rdata.port)
+            return SMTPHost(
+                host=host,
+                port=port,
+                ssl=port == 465,
+                starttls=port == 587,
+            )
+    return None
+
+
+def _lookup_smtp_mx(domain: str) -> Optional[SMTPHost]:
+    if not _HAS_DNS:
+        return None
+    try:
+        answers = dns.resolver.resolve(domain, "MX", lifetime=3.0)
+    except DNSException:
+        return None
+    for rdata in sorted(answers, key=lambda r: r.preference):
+        host = str(rdata.exchange).rstrip(".").lower()
+        for hint, smtp in SMTP_MX_HINTS:
+            if hint in host:
+                return smtp
+    return None
+
+
+def resolve_smtp_host(address: str) -> SMTPHost:
+    """Discover the SMTP host for an email address.
+
+    Mirrors :func:`resolve_imap_host`: known providers, DNS SRV, DNS MX hints,
+    convention fallback (``smtp.<domain>`` on 465/SSL).
+    """
+    _, domain = _split_email(address)
+
+    if domain in KNOWN_SMTP_PROVIDERS:
+        return KNOWN_SMTP_PROVIDERS[domain]
+
+    srv = _lookup_smtp_srv(domain)
+    if srv is not None:
+        return srv
+
+    mx = _lookup_smtp_mx(domain)
+    if mx is not None:
+        return mx
+
+    return SMTPHost(host=f"smtp.{domain}")

--- a/email_profile/queries.py
+++ b/email_profile/queries.py
@@ -1,0 +1,33 @@
+"""High-level query shortcuts that operate on the inbox."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from email_profile.folders import FolderAccess
+from email_profile.searches import Where
+
+
+class QueryShortcuts:
+    """Convenience queries over :attr:`FolderAccess.inbox`."""
+
+    def __init__(self, folders: FolderAccess) -> None:
+        self._folders = folders
+
+    def unread(self) -> Where:
+        """Unread messages in the inbox."""
+        return self._folders.inbox.where(unseen=True)
+
+    def recent(self, days: int = 7) -> Where:
+        """Messages from the last N days."""
+        return self._folders.inbox.where(
+            since=date.today() - timedelta(days=days)
+        )
+
+    def search(self, text: str) -> Where:
+        """Full-text search in the inbox."""
+        return self._folders.inbox.where(text=text)
+
+    def all(self) -> Where:
+        """All messages in the inbox."""
+        return self._folders.inbox.where()

--- a/email_profile/sender.py
+++ b/email_profile/sender.py
@@ -1,0 +1,149 @@
+"""High-level send / reply / forward on top of SmtpClient."""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Optional, Union
+
+from email_profile.imap_session import IMAPSession
+from email_profile.providers import resolve_smtp_host
+from email_profile.smtp import AttachmentLike, SmtpClient, _build_message
+
+if TYPE_CHECKING:
+    from email.message import EmailMessage
+
+    from email_profile.eml import EmailSerializer
+    from email_profile.folders import FolderAccess
+    from email_profile.types import SMTPHost
+
+
+class Sender:
+    """Outgoing-mail facade: send, reply, forward."""
+
+    def __init__(self, session: IMAPSession, folders: FolderAccess) -> None:
+        self._session = session
+        self._folders = folders
+        self._smtp_host: Optional[SMTPHost] = None
+
+    def smtp_host(self) -> SMTPHost:
+        """Resolved SMTP host for this account. Cached after first call."""
+        if self._smtp_host is None:
+            self._smtp_host = resolve_smtp_host(self._session.user)
+        return self._smtp_host
+
+    def send(
+        self,
+        to: Union[str, list[str]],
+        subject: str,
+        body: str = "",
+        *,
+        html: Optional[str] = None,
+        cc: Optional[Union[str, list[str]]] = None,
+        bcc: Optional[Union[str, list[str]]] = None,
+        reply_to: Optional[str] = None,
+        attachments: Optional[list[AttachmentLike]] = None,
+        headers: Optional[dict[str, str]] = None,
+        save_to_sent: bool = True,
+    ) -> None:
+        """Send an email via SMTP, optionally appending to Sent."""
+        message = _build_message(
+            sender=self._session.user,
+            to=to,
+            subject=subject,
+            body=body,
+            html=html,
+            cc=cc,
+            bcc=bcc,
+            reply_to=reply_to,
+            attachments=attachments,
+            headers=headers,
+        )
+        self.send_message(message, save_to_sent=save_to_sent)
+
+    def send_message(
+        self,
+        message: EmailMessage,
+        *,
+        save_to_sent: bool = True,
+    ) -> None:
+        """Send a pre-built EmailMessage."""
+        if not message.get("From"):
+            message["From"] = self._session.user
+
+        with SmtpClient(
+            host=self.smtp_host(),
+            user=self._session.user,
+            password=self._session.password,
+        ) as client:
+            client.send(message)
+
+        if save_to_sent and self._session.is_connected:
+            with contextlib.suppress(KeyError):
+                self._folders.sent.append(message.as_bytes())
+
+    def reply(
+        self,
+        original: EmailSerializer,
+        body: str = "",
+        *,
+        html: Optional[str] = None,
+        attachments: Optional[list[AttachmentLike]] = None,
+        reply_all: bool = False,
+        save_to_sent: bool = True,
+    ) -> None:
+        """Reply to a previously-fetched message, preserving threading."""
+        subject = original.subject or ""
+        if not subject.lower().startswith("re:"):
+            subject = f"Re: {subject}"
+
+        to = original.reply_to or original.from_ or ""
+        cc = original.cc if reply_all else None
+
+        headers: dict[str, str] = {}
+        if original.id:
+            headers["In-Reply-To"] = original.id
+            refs = (original.references or "").split()
+            refs.append(original.id)
+            headers["References"] = " ".join(refs)
+
+        self.send(
+            to=to,
+            subject=subject,
+            body=body,
+            html=html,
+            cc=cc,
+            attachments=attachments,
+            headers=headers,
+            save_to_sent=save_to_sent,
+        )
+
+    def forward(
+        self,
+        original: EmailSerializer,
+        to: Union[str, list[str]],
+        body: str = "",
+        *,
+        attachments: Optional[list[AttachmentLike]] = None,
+        save_to_sent: bool = True,
+    ) -> None:
+        """Forward a previously-fetched message to new recipients."""
+        subject = original.subject or ""
+        if not subject.lower().startswith("fwd:"):
+            subject = f"Fwd: {subject}"
+
+        quoted = (
+            f"\n\n---------- Forwarded message ----------\n"
+            f"From: {original.from_}\n"
+            f"Date: {original.date}\n"
+            f"Subject: {original.subject}\n"
+            f"To: {original.to_}\n\n"
+            f"{original.body_text_plain}"
+        )
+
+        self.send(
+            to=to,
+            subject=subject,
+            body=(body + quoted) if body else quoted,
+            attachments=attachments,
+            save_to_sent=save_to_sent,
+        )

--- a/email_profile/smtp.py
+++ b/email_profile/smtp.py
@@ -1,0 +1,151 @@
+"""SMTP client for outgoing mail."""
+
+from __future__ import annotations
+
+import mimetypes
+import smtplib
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Optional, Union
+
+from email_profile.retry import with_retry
+from email_profile.types import SMTPHost
+
+AttachmentLike = Union[
+    str,
+    Path,
+    tuple[str, bytes],
+    tuple[str, bytes, str],
+]
+
+
+def _build_message(
+    *,
+    sender: str,
+    to: Union[str, list[str]],
+    subject: str,
+    body: str = "",
+    html: Optional[str] = None,
+    cc: Optional[Union[str, list[str]]] = None,
+    bcc: Optional[Union[str, list[str]]] = None,
+    reply_to: Optional[str] = None,
+    attachments: Optional[list[AttachmentLike]] = None,
+    headers: Optional[dict[str, str]] = None,
+) -> EmailMessage:
+    """Build an :class:`email.message.EmailMessage` from keyword arguments."""
+
+    msg = EmailMessage()
+    msg["From"] = sender
+    msg["To"] = to if isinstance(to, str) else ", ".join(to)
+    msg["Subject"] = subject
+
+    if cc:
+        msg["Cc"] = cc if isinstance(cc, str) else ", ".join(cc)
+    if bcc:
+        msg["Bcc"] = bcc if isinstance(bcc, str) else ", ".join(bcc)
+    if reply_to:
+        msg["Reply-To"] = reply_to
+    if headers:
+        for name, value in headers.items():
+            msg[name] = value
+
+    msg.set_content(body or "")
+
+    if html:
+        msg.add_alternative(html, subtype="html")
+
+    for item in attachments or []:
+        _attach(msg, item)
+
+    return msg
+
+
+def _attach(msg: EmailMessage, item: AttachmentLike) -> None:
+    if isinstance(item, (str, Path)):
+        path = Path(item)
+        data = path.read_bytes()
+        filename = path.name
+        ctype, _ = mimetypes.guess_type(filename)
+    elif isinstance(item, tuple) and len(item) == 2:
+        filename, data = item
+        ctype, _ = mimetypes.guess_type(filename)
+    elif isinstance(item, tuple) and len(item) == 3:
+        filename, data, ctype = item
+    else:
+        raise TypeError(
+            "Attachment must be a path, (name, bytes) or (name, bytes, mime)."
+        )
+
+    maintype, subtype = (ctype or "application/octet-stream").split("/", 1)
+    msg.add_attachment(
+        data, maintype=maintype, subtype=subtype, filename=filename
+    )
+
+
+class SmtpClient:
+    """Low-level SMTP client. Reuse via ``with`` for batch sends."""
+
+    def __init__(
+        self,
+        host: SMTPHost,
+        user: str,
+        password: str,
+    ) -> None:
+        self._host = host
+        self._user = user
+        self._password = password
+        self._smtp: Optional[smtplib.SMTP] = None
+
+    @property
+    def host(self) -> SMTPHost:
+        return self._host
+
+    @property
+    def user(self) -> str:
+        return self._user
+
+    @property
+    def is_connected(self) -> bool:
+        return self._smtp is not None
+
+    def connect(self) -> SmtpClient:
+        if self._host.ssl:
+            smtp: smtplib.SMTP = smtplib.SMTP_SSL(
+                self._host.host, self._host.port
+            )
+        else:
+            smtp = smtplib.SMTP(self._host.host, self._host.port)
+            if self._host.starttls:
+                smtp.starttls()
+        smtp.login(self._user, self._password)
+        self._smtp = smtp
+        return self
+
+    def close(self) -> None:
+        if self._smtp is not None:
+            try:
+                self._smtp.quit()
+            finally:
+                self._smtp = None
+
+    def send(self, message: EmailMessage) -> None:
+        """Send a pre-built message through the current SMTP session."""
+        if self._smtp is None:
+            raise RuntimeError(
+                "SmtpClient is not connected. Use `with` or call connect()."
+            )
+        send_fn = with_retry()(self._smtp.send_message)
+        send_fn(message)
+
+    def __enter__(self) -> SmtpClient:
+        return self.connect()
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def __repr__(self) -> str:
+        state = "connected" if self.is_connected else "disconnected"
+        return (
+            f"SmtpClient(host={self._host.host!r}, "
+            f"user={self._user!r}, {state})"
+        )

--- a/email_profile/types.py
+++ b/email_profile/types.py
@@ -15,6 +15,16 @@ class IMAPHost:
 
 
 @dataclass(frozen=True)
+class SMTPHost:
+    """The SMTP host + port + SSL/STARTTLS mode for outgoing mail."""
+
+    host: str
+    port: int = 465
+    ssl: bool = True
+    starttls: bool = False
+
+
+@dataclass(frozen=True)
 class AppendedUID:
     """Result of a successful IMAP APPEND when the server supports UIDPLUS."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,8 @@ def app(fake_client):
     """A connected Email app talking to a fake IMAP server."""
     with (
         patch(
-            "email_profile.email.imaplib.IMAP4_SSL", return_value=fake_client
+            "email_profile.imap_session.imaplib.IMAP4_SSL",
+            return_value=fake_client,
         ),
         Email("imap.x", "u", "p") as connected,
     ):
@@ -93,7 +94,8 @@ def gmail_app(gmail_client):
     """A connected Email app with Gmail-style mailbox names."""
     with (
         patch(
-            "email_profile.email.imaplib.IMAP4_SSL", return_value=gmail_client
+            "email_profile.imap_session.imaplib.IMAP4_SSL",
+            return_value=gmail_client,
         ),
         Email("imap.x", "u", "p") as connected,
     ):

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -8,13 +8,17 @@ from tests.conftest import GMAIL_LIST, make_fake_client
 class TestConnection(TestCase):
     def test_does_not_connect_eagerly(self):
         fake = make_fake_client()
-        with patch("email_profile.email.imaplib.IMAP4_SSL", return_value=fake):
+        with patch(
+            "email_profile.imap_session.imaplib.IMAP4_SSL", return_value=fake
+        ):
             Email("imap.x", "u", "p")
         fake.login.assert_not_called()
 
     def test_mailbox_requires_connection(self):
         fake = make_fake_client()
-        with patch("email_profile.email.imaplib.IMAP4_SSL", return_value=fake):
+        with patch(
+            "email_profile.imap_session.imaplib.IMAP4_SSL", return_value=fake
+        ):
             app = Email("imap.x", "u", "p")
         with self.assertRaises(NotConnected):
             app.mailbox("INBOX")
@@ -22,7 +26,10 @@ class TestConnection(TestCase):
     def test_context_manager_logs_in_and_out(self):
         fake = make_fake_client()
         with (
-            patch("email_profile.email.imaplib.IMAP4_SSL", return_value=fake),
+            patch(
+                "email_profile.imap_session.imaplib.IMAP4_SSL",
+                return_value=fake,
+            ),
             Email("imap.x", "u", "p") as app,
         ):
             self.assertIn("INBOX", app.mailboxes())
@@ -32,7 +39,10 @@ class TestConnection(TestCase):
     def test_unknown_mailbox_raises(self):
         fake = make_fake_client()
         with (
-            patch("email_profile.email.imaplib.IMAP4_SSL", return_value=fake),
+            patch(
+                "email_profile.imap_session.imaplib.IMAP4_SSL",
+                return_value=fake,
+            ),
             Email("imap.x", "u", "p") as app,
             self.assertRaises(KeyError),
         ):
@@ -41,29 +51,29 @@ class TestConnection(TestCase):
 
 class TestProviderFactories(TestCase):
     def test_gmail(self):
-        self.assertEqual(Email.gmail("u", "p")._server, "imap.gmail.com")
+        self.assertEqual(Email.gmail("u", "p").server, "imap.gmail.com")
 
     def test_outlook(self):
         self.assertEqual(
-            Email.outlook("u", "p")._server, "outlook.office365.com"
+            Email.outlook("u", "p").server, "outlook.office365.com"
         )
 
     def test_icloud(self):
-        self.assertEqual(Email.icloud("u", "p")._server, "imap.mail.me.com")
+        self.assertEqual(Email.icloud("u", "p").server, "imap.mail.me.com")
 
     def test_yahoo(self):
-        self.assertEqual(Email.yahoo("u", "p")._server, "imap.mail.yahoo.com")
+        self.assertEqual(Email.yahoo("u", "p").server, "imap.mail.yahoo.com")
 
     def test_hostinger(self):
         self.assertEqual(
-            Email.hostinger("u", "p")._server, "imap.hostinger.com"
+            Email.hostinger("u", "p").server, "imap.hostinger.com"
         )
 
     def test_zoho(self):
-        self.assertEqual(Email.zoho("u", "p")._server, "imap.zoho.com")
+        self.assertEqual(Email.zoho("u", "p").server, "imap.zoho.com")
 
     def test_fastmail(self):
-        self.assertEqual(Email.fastmail("u", "p")._server, "imap.fastmail.com")
+        self.assertEqual(Email.fastmail("u", "p").server, "imap.fastmail.com")
 
 
 class TestFromEmail(TestCase):
@@ -114,7 +124,8 @@ class TestMailboxProperties(TestCase):
     def setUp(self):
         self.fake = make_fake_client(mailboxes=GMAIL_LIST)
         self._patcher = patch(
-            "email_profile.email.imaplib.IMAP4_SSL", return_value=self.fake
+            "email_profile.imap_session.imaplib.IMAP4_SSL",
+            return_value=self.fake,
         )
         self._patcher.start()
         self.app = Email("imap.x", "u", "p").connect()
@@ -143,7 +154,8 @@ class TestQueryShortcuts(TestCase):
     def setUp(self):
         self.fake = make_fake_client()
         self._patcher = patch(
-            "email_profile.email.imaplib.IMAP4_SSL", return_value=self.fake
+            "email_profile.imap_session.imaplib.IMAP4_SSL",
+            return_value=self.fake,
         )
         self._patcher.start()
         self.app = Email("imap.x", "u", "p").connect()
@@ -189,7 +201,10 @@ class TestPublicProperties(TestCase):
     def test_is_connected_true_after_connect(self):
         fake = make_fake_client()
         with (
-            patch("email_profile.email.imaplib.IMAP4_SSL", return_value=fake),
+            patch(
+                "email_profile.imap_session.imaplib.IMAP4_SSL",
+                return_value=fake,
+            ),
             Email("imap.x", "u", "p") as app,
         ):
             self.assertTrue(app.is_connected)
@@ -209,7 +224,7 @@ class TestConstructorOverloads(TestCase):
         from email_profile import IMAPHost
 
         with patch(
-            "email_profile.email.resolve_imap_host",
+            "email_profile.factories.resolve_imap_host",
             return_value=IMAPHost("imap.test"),
         ):
             app = Email("u@test.example", "pw")
@@ -227,16 +242,20 @@ class TestConstructorOverloads(TestCase):
                 },
                 clear=True,
             ),
-            patch("email_profile.email.Email._build_from_env") as build,
+            patch("email_profile.email.EmailFactories.from_env") as build,
         ):
-            build.return_value = ("imap.x.com", "u@x.com", "pw")
+            from email_profile.factories import Credentials
+
+            build.return_value = Credentials(
+                server="imap.x.com", user="u@x.com", password="pw"
+            )
             app = Email()
         self.assertEqual(app.server, "imap.x.com")
 
     def test_zero_args_without_env_raises(self):
         with (
             patch(
-                "email_profile.email.Email._build_from_env",
+                "email_profile.email.EmailFactories.from_env",
                 side_effect=KeyError("nope"),
             ),
             self.assertRaises(KeyError),
@@ -252,7 +271,10 @@ class TestNoop(TestCase):
     def test_noop_calls_imap_noop(self):
         fake = make_fake_client()
         with (
-            patch("email_profile.email.imaplib.IMAP4_SSL", return_value=fake),
+            patch(
+                "email_profile.imap_session.imaplib.IMAP4_SSL",
+                return_value=fake,
+            ),
             Email("imap.x", "u", "p") as app,
         ):
             app.noop()
@@ -281,7 +303,8 @@ class TestRestore(TestCase):
             fake = make_fake_client()
             with (
                 patch(
-                    "email_profile.email.imaplib.IMAP4_SSL", return_value=fake
+                    "email_profile.imap_session.imaplib.IMAP4_SSL",
+                    return_value=fake,
                 ),
                 Email("imap.x", "u", "p") as app,
             ):
@@ -308,7 +331,8 @@ class TestRestore(TestCase):
             fake = make_fake_client()
             with (
                 patch(
-                    "email_profile.email.imaplib.IMAP4_SSL", return_value=fake
+                    "email_profile.imap_session.imaplib.IMAP4_SSL",
+                    return_value=fake,
                 ),
                 Email("imap.x", "u", "p") as app,
                 self.assertRaises(KeyError),
@@ -333,7 +357,8 @@ class TestRestore(TestCase):
             fake = make_fake_client()
             with (
                 patch(
-                    "email_profile.email.imaplib.IMAP4_SSL", return_value=fake
+                    "email_profile.imap_session.imaplib.IMAP4_SSL",
+                    return_value=fake,
                 ),
                 Email("imap.x", "u", "p") as app,
             ):

--- a/tests/test_mailbox.py
+++ b/tests/test_mailbox.py
@@ -9,7 +9,8 @@ class TestMailBoxWhere(TestCase):
     def setUp(self):
         self.fake = make_fake_client()
         self._patcher = patch(
-            "email_profile.email.imaplib.IMAP4_SSL", return_value=self.fake
+            "email_profile.imap_session.imaplib.IMAP4_SSL",
+            return_value=self.fake,
         )
         self._patcher.start()
         self.app = Email("imap.x", "u", "p").connect()
@@ -40,7 +41,8 @@ class TestMailBoxAppend(TestCase):
     def setUp(self):
         self.fake = make_fake_client()
         self._patcher = patch(
-            "email_profile.email.imaplib.IMAP4_SSL", return_value=self.fake
+            "email_profile.imap_session.imaplib.IMAP4_SSL",
+            return_value=self.fake,
         )
         self._patcher.start()
         self.app = Email("imap.x", "u", "p").connect()

--- a/tests/test_searches.py
+++ b/tests/test_searches.py
@@ -9,7 +9,8 @@ class TestWhereLazy(TestCase):
     def setUp(self):
         self.fake = make_fake_client()
         self._patcher = patch(
-            "email_profile.email.imaplib.IMAP4_SSL", return_value=self.fake
+            "email_profile.imap_session.imaplib.IMAP4_SSL",
+            return_value=self.fake,
         )
         self._patcher.start()
         self.app = Email("imap.x", "u", "p").connect()
@@ -46,7 +47,8 @@ class TestFetchModes(TestCase):
     def setUp(self):
         self.fake = make_fake_client()
         self._patcher = patch(
-            "email_profile.email.imaplib.IMAP4_SSL", return_value=self.fake
+            "email_profile.imap_session.imaplib.IMAP4_SSL",
+            return_value=self.fake,
         )
         self._patcher.start()
         self.app = Email("imap.x", "u", "p").connect()
@@ -84,7 +86,8 @@ class TestChunkAndProgress(TestCase):
     def setUp(self):
         self.fake = make_fake_client()
         self._patcher = patch(
-            "email_profile.email.imaplib.IMAP4_SSL", return_value=self.fake
+            "email_profile.imap_session.imaplib.IMAP4_SSL",
+            return_value=self.fake,
         )
         self._patcher.start()
         self.app = Email("imap.x", "u", "p").connect()
@@ -115,7 +118,8 @@ class TestUidsCache(TestCase):
     def setUp(self):
         self.fake = make_fake_client()
         self._patcher = patch(
-            "email_profile.email.imaplib.IMAP4_SSL", return_value=self.fake
+            "email_profile.imap_session.imaplib.IMAP4_SSL",
+            return_value=self.fake,
         )
         self._patcher.start()
         self.app = Email("imap.x", "u", "p").connect()

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -1,0 +1,130 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from email_profile import Email, EmailSerializer, SMTPHost
+from tests.conftest import SAMPLE_RFC822, make_fake_client
+
+
+def _smtp_patches(fake_smtp):
+    return (
+        patch("email_profile.smtp.smtplib.SMTP_SSL", return_value=fake_smtp),
+        patch("email_profile.smtp.smtplib.SMTP", return_value=fake_smtp),
+        patch(
+            "email_profile.sender.resolve_smtp_host",
+            return_value=SMTPHost("smtp.test", port=465, ssl=True),
+        ),
+    )
+
+
+class _SendTest(TestCase):
+    def setUp(self):
+        self.imap = make_fake_client()
+        self.smtp = MagicMock()
+
+        self._imap_patch = patch(
+            "email_profile.imap_session.imaplib.IMAP4_SSL",
+            return_value=self.imap,
+        )
+        ssl_patch, plain_patch, resolve_patch = _smtp_patches(self.smtp)
+        self._smtp_ssl_patch = ssl_patch
+        self._smtp_plain_patch = plain_patch
+        self._resolve_patch = resolve_patch
+
+        for p in (
+            self._imap_patch,
+            self._smtp_ssl_patch,
+            self._smtp_plain_patch,
+            self._resolve_patch,
+        ):
+            p.start()
+
+        self.app = Email("imap.x", "u@x.com", "pw").connect()
+
+    def tearDown(self):
+        self.app.close()
+        for p in (
+            self._imap_patch,
+            self._smtp_ssl_patch,
+            self._smtp_plain_patch,
+            self._resolve_patch,
+        ):
+            p.stop()
+
+
+class TestSend(_SendTest):
+    def test_send_calls_smtp(self):
+        self.app.send(to="bob@x", subject="Hi", body="hello")
+        self.smtp.login.assert_called_once_with("u@x.com", "pw")
+        self.smtp.send_message.assert_called_once()
+
+    def test_send_saves_to_sent(self):
+        self.app.send(to="bob@x", subject="Hi", body="hello")
+        self.imap.append.assert_called_once()
+
+    def test_send_can_skip_save_to_sent(self):
+        self.app.send(
+            to="bob@x", subject="Hi", body="hello", save_to_sent=False
+        )
+        self.imap.append.assert_not_called()
+
+    def test_send_sets_from_when_missing(self):
+        from email.message import EmailMessage
+
+        msg = EmailMessage()
+        msg["To"] = "bob@x"
+        msg["Subject"] = "t"
+        msg.set_content("body")
+
+        self.app.send_message(msg, save_to_sent=False)
+        sent = self.smtp.send_message.call_args[0][0]
+        self.assertEqual(sent["From"], "u@x.com")
+
+
+class TestReply(_SendTest):
+    def test_reply_preserves_threading(self):
+        original = EmailSerializer.from_raw(
+            uid="1", mailbox="INBOX", raw=SAMPLE_RFC822
+        )
+        original_id = original.id
+
+        self.app.reply(original, body="thanks")
+
+        sent = self.smtp.send_message.call_args[0][0]
+        self.assertTrue(sent["Subject"].startswith("Re:"))
+        self.assertEqual(sent["In-Reply-To"], original_id)
+        self.assertIn(original_id, sent["References"])
+
+    def test_reply_does_not_double_re_prefix(self):
+        raw = SAMPLE_RFC822.replace(b"Subject: Hello", b"Subject: Re: hi")
+        original = EmailSerializer.from_raw(uid="1", mailbox="INBOX", raw=raw)
+        self.app.reply(original, body="ok", save_to_sent=False)
+        sent = self.smtp.send_message.call_args[0][0]
+        self.assertFalse(sent["Subject"].lower().startswith("re: re:"))
+
+
+class TestForward(_SendTest):
+    def test_forward_prefixes_subject(self):
+        original = EmailSerializer.from_raw(
+            uid="1", mailbox="INBOX", raw=SAMPLE_RFC822
+        )
+        self.app.forward(original, to="carol@x")
+        sent = self.smtp.send_message.call_args[0][0]
+        self.assertTrue(sent["Subject"].startswith("Fwd:"))
+
+    def test_forward_quotes_original(self):
+        original = EmailSerializer.from_raw(
+            uid="1",
+            mailbox="INBOX",
+            raw=SAMPLE_RFC822,
+            from_="alice@example.com",
+            to_="bob@example.com",
+        )
+        self.app.forward(original, to="carol@x", body="please see below")
+        sent = self.smtp.send_message.call_args[0][0]
+        text = ""
+        for part in sent.walk():
+            if part.get_content_type() == "text/plain":
+                text = part.get_content()
+                break
+        self.assertIn("Forwarded message", text)
+        self.assertIn("alice@example.com", text)

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -1,0 +1,103 @@
+from email.message import EmailMessage
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from email_profile import SmtpClient
+from email_profile.smtp import _build_message
+from email_profile.types import SMTPHost
+
+
+class TestBuildMessage(TestCase):
+    def test_basic_text(self):
+        msg = _build_message(
+            sender="me@x", to="you@x", subject="hi", body="hello"
+        )
+        self.assertEqual(msg["From"], "me@x")
+        self.assertEqual(msg["To"], "you@x")
+        self.assertEqual(msg["Subject"], "hi")
+        self.assertIn("hello", msg.get_content())
+
+    def test_html_alternative(self):
+        msg = _build_message(
+            sender="me@x",
+            to="you@x",
+            subject="hi",
+            body="plain",
+            html="<p>html</p>",
+        )
+        self.assertTrue(msg.is_multipart())
+
+    def test_list_recipients_joined(self):
+        msg = _build_message(
+            sender="me@x",
+            to=["a@x", "b@x"],
+            subject="hi",
+            cc=["c@x"],
+        )
+        self.assertEqual(msg["To"], "a@x, b@x")
+        self.assertEqual(msg["Cc"], "c@x")
+
+    def test_custom_headers(self):
+        msg = _build_message(
+            sender="me@x",
+            to="you@x",
+            subject="hi",
+            headers={"In-Reply-To": "<prev@x>"},
+        )
+        self.assertEqual(msg["In-Reply-To"], "<prev@x>")
+
+    def test_attachment_from_bytes_tuple(self):
+        msg = _build_message(
+            sender="me@x",
+            to="you@x",
+            subject="hi",
+            attachments=[("note.txt", b"hello")],
+        )
+        parts = list(msg.iter_attachments())
+        self.assertEqual(len(parts), 1)
+        self.assertEqual(parts[0].get_filename(), "note.txt")
+
+
+class TestSmtpClientSSL(TestCase):
+    def setUp(self):
+        self.host = SMTPHost("smtp.x", port=465, ssl=True)
+        self.fake = MagicMock()
+        self._patcher = patch(
+            "email_profile.smtp.smtplib.SMTP_SSL", return_value=self.fake
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_connect_logs_in(self):
+        SmtpClient(self.host, "u", "pw").connect()
+        self.fake.login.assert_called_once_with("u", "pw")
+
+    def test_context_manager_quits(self):
+        with SmtpClient(self.host, "u", "pw") as client:
+            self.assertTrue(client.is_connected)
+        self.fake.quit.assert_called_once()
+
+    def test_send_delegates_to_send_message(self):
+        msg = EmailMessage()
+        with SmtpClient(self.host, "u", "pw") as client:
+            client.send(msg)
+        self.fake.send_message.assert_called_once_with(msg)
+
+
+class TestSmtpClientStartTLS(TestCase):
+    def test_starttls_upgrades(self):
+        host = SMTPHost("smtp.x", port=587, ssl=False, starttls=True)
+        fake = MagicMock()
+        with patch("email_profile.smtp.smtplib.SMTP", return_value=fake):
+            SmtpClient(host, "u", "pw").connect()
+        fake.starttls.assert_called_once()
+        fake.login.assert_called_once_with("u", "pw")
+
+
+class TestSmtpClientErrors(TestCase):
+    def test_send_before_connect_raises(self):
+        client = SmtpClient(SMTPHost("smtp.x"), "u", "pw")
+        with self.assertRaises(RuntimeError):
+            client.send(EmailMessage())

--- a/tests/test_write_ops.py
+++ b/tests/test_write_ops.py
@@ -9,7 +9,8 @@ class _WriteTest(TestCase):
     def setUp(self):
         self.fake = make_fake_client()
         self._patcher = patch(
-            "email_profile.email.imaplib.IMAP4_SSL", return_value=self.fake
+            "email_profile.imap_session.imaplib.IMAP4_SSL",
+            return_value=self.fake,
         )
         self._patcher.start()
         self.app = Email("imap.x", "u", "p").connect()


### PR DESCRIPTION
Closes #18

## Summary

Two things land in this PR:

1. **SMTP send** (issue #18) — the library is no longer read-only. `Email` now speaks both IMAP and SMTP with the same auto-discovery ergonomics.
2. **Email refactor** — the 551-line `Email` class is split into 6 collaborating classes via composition. Public API is 100% preserved.

## New send API

```python
with Email(user="you@yourdomain.com", password="pw") as app:
    app.send(
        to="bob@example.com",
        subject="Hello",
        body="Plain text",
        html="<p>HTML too</p>",
        attachments=["./report.pdf"],
        cc=["alice@x"],
        save_to_sent=True,      # appends to Sent via IMAP after SMTP send
    )

    original = next(app.inbox.where(subject="invoice").messages())
    app.reply(original, body="Thanks!")              # preserves In-Reply-To/References
    app.forward(original, to="carol@x")              # Fwd: + quoted body
```

SMTP host is resolved the same way as IMAP: known providers → DNS SRV `_submission._tcp` → MX hints → `smtp.<domain>`. Gmail/Yahoo/Hostinger go 465 SSL; Outlook/iCloud go 587 STARTTLS.

## Architecture

`Email` is now a thin coordinator over composed sub-objects:

| Attribute | Class | File |
|---|---|---|
| `_session` | `IMAPSession` | `imap_session.py` |
| `_folders` | `FolderAccess` | `folders.py` |
| `_queries` | `QueryShortcuts` | `queries.py` |
| `_backup` | `RestoreOps` | `backup.py` |
| `_sender` | `Sender` | `sender.py` |
| n/a | `EmailFactories` + `Credentials` | `factories.py` |

`SmtpClient` (low-level SSL/STARTTLS + retry) lives in `smtp.py`.

## Files

**New**
- `email_profile/smtp.py` — `SmtpClient`, `_build_message` (attachments, html, cc/bcc)
- `email_profile/sender.py` — `Sender` (send/reply/forward)
- `email_profile/imap_session.py` — `IMAPSession`
- `email_profile/queries.py` — `QueryShortcuts`
- `email_profile/backup.py` — `RestoreOps`
- `email_profile/factories.py` — `EmailFactories`, `Credentials`
- `tests/test_smtp.py` — 11 tests (message builder, SSL, STARTTLS, errors)
- `tests/test_send.py` — 7 tests (send, reply threading, forward quoting)
- `docs_src/send_email.py`, `reply_email.py`, `forward_email.py`

**Changed**
- `email_profile/email.py` — 551 → 323 lines, pure delegation
- `email_profile/types.py` — `+ SMTPHost`
- `email_profile/providers.py` — `+ KNOWN_SMTP_PROVIDERS`, `+ SMTP_MX_HINTS`, `+ resolve_smtp_host`
- `email_profile/folders.py` — `+ FolderAccess` class (hints + matcher stay here)
- `email_profile/__init__.py` + `advanced.py` — expose new symbols
- Fake IMAP client (`tests/conftest.py`) grows append/expunge/create/delete/rename support

## Backwards compatibility

Zero breaks. Every public name that existed still works:

- `Email(...)`, `Email.gmail(...)`, `Email.from_env(...)`, `app.connect()`, `app.unread()`, `app.restore()`, `app.mailbox(...)` — unchanged.
- New methods are additive: `app.send`, `app.reply`, `app.forward`, `app.send_message`, `app.smtp_host()`.

## Testing

- **165 passed** (was 147 before this PR).
- ruff clean, flake8 clean, ruff format clean.
- Smoke-tested locally against Hostinger SMTP/IMAP on a real account.

## Known debt (tracked in follow-up issues)

See the issues below this PR for:
- Deduplicating `Email.from_email` vs `EmailFactories.from_address`.
- Renaming `factories.py` to something clearer.
- Uniform naming across `IMAPSession` / `SmtpClient`.
- Removing dead `EmailFactories.PROVIDER_HOSTS` (or wiring it up to the provider classmethods).

## Test plan

- [x] `pytest tests/` — 165 green
- [x] `ruff check` + `ruff format --check` — clean
- [x] `flake8` — clean
- [ ] Smoke run `docs_src/send_email.py` with a real account (done locally)