### PR TITLE
⚙️ FEATURE-#20: Dedupe Email.from_email / EmailFactories.from_address

### DIFF
--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -81,7 +81,7 @@ class TestFromEmail(TestCase):
         from email_profile import IMAPHost
 
         with patch(
-            "email_profile.email.resolve_imap_host",
+            "email_profile.factories.resolve_imap_host",
             return_value=IMAPHost("imap.test", port=993),
         ):
             app = Email.from_email("a@test.example", "pw")


### PR DESCRIPTION
Closes #20

## Summary

`Email.from_email` and `EmailFactories.from_address` were both calling `resolve_imap_host` and packing the result manually — two sources of truth for the same operation.

This PR keeps `EmailFactories.from_address` as the single implementation and reroutes `Email.from_email` through it.

## Diff

```python
@classmethod
def from_email(cls, address: str, password: str) -> Email:
    creds = EmailFactories.from_address(address, password)
    return cls(
        server=creds.server,
        user=creds.user,
        password=creds.password,
        port=creds.port,
        ssl=creds.ssl,
    )
```

Top-level import of `resolve_imap_host` in `email.py` is removed (no longer needed).

## Test fix

`tests/test_email.py::TestFromEmail::test_uses_resolver` now patches `email_profile.factories.resolve_imap_host` (the real call site) instead of `email_profile.email.resolve_imap_host`.

## Test plan

- [x] 165 tests pass
- [x] ruff + flake8 + format clean