### PR TITLE
🪲 BUG-#42: Include flags field in StorageSQLite.get() response

### DIFF
--- a/email_profile/storage/sqlite.py
+++ b/email_profile/storage/sqlite.py
@@ -98,6 +98,7 @@ class StorageSQLite(StorageABC):
                 uid=row.uid,
                 mailbox=row.mailbox,
                 file=row.file,
+                flags=row.flags,
             )
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Summary

- `StorageSQLite.get()` was constructing a `RawSerializer` without passing the `flags` field, causing it to be silently dropped during round-trips.
- Added `flags=row.flags` to the `RawSerializer` constructor call.

Closes #42