### PR TITLE
🪲 BUG-#44: Try common charset fallbacks before using replacement characters

### DIFF
--- a/email_profile/parser.py
+++ b/email_profile/parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from email import message_from_bytes
 from email.header import decode_header
@@ -11,6 +12,8 @@ from pathlib import Path
 from typing import Optional, Union
 
 from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
 
 _NAMED_HEADERS = frozenset(
     name.lower()
@@ -108,11 +111,23 @@ def _decode_payload(part: PyEmailMessage) -> str:
 
     if isinstance(payload, bytes):
         charset = part.get_content_charset() or "utf-8"
+        fallbacks = [charset, "utf-8", "latin-1", "windows-1252"]
+        seen: set[str] = set()
 
-        try:
-            return payload.decode(charset, errors="replace")
-        except (LookupError, TypeError):
-            return payload.decode("utf-8", errors="replace")
+        for enc in fallbacks:
+            if enc in seen:
+                continue
+            seen.add(enc)
+            try:
+                return payload.decode(enc)
+            except (UnicodeDecodeError, LookupError):
+                continue
+
+        logger.warning(
+            "Could not decode payload with charsets %s, using replacement characters.",
+            list(seen),
+        )
+        return payload.decode("utf-8", errors="replace")
 
     return str(payload)
 

--- a/email_profile/parser.py
+++ b/email_profile/parser.py
@@ -111,7 +111,7 @@ def _decode_payload(part: PyEmailMessage) -> str:
 
     if isinstance(payload, bytes):
         charset = part.get_content_charset() or "utf-8"
-        fallbacks = [charset, "utf-8", "latin-1", "windows-1252"]
+        fallbacks = [charset, "utf-8", "windows-1252", "latin-1"]
         seen: set[str] = set()
 
         for enc in fallbacks:


### PR DESCRIPTION
## Summary
- Fixes #44: `_decode_payload()` previously used `errors="replace"` which silently corrupts non-UTF-8 email content
- Now tries a fallback chain of common charsets (declared charset, utf-8, latin-1, windows-1252) before resorting to replacement characters
- Logs a warning when all charset attempts fail and replacement characters are used as a last resort

## Test plan
- [x] All 149 existing tests pass (`python -m pytest tests/ -x -q`)
- [ ] Verify emails with latin-1 or windows-1252 content decode correctly without replacement characters
- [ ] Verify warning is logged when no charset in the fallback chain can decode the payload