### PR TITLE
Lazily initialize storage to avoid creating email.db unnecessarily

### DIFF
--- a/email_profile/email.py
+++ b/email_profile/email.py
@@ -60,7 +60,17 @@ class Email:
         self._sync = Sync(self._session)
         self._restore = Restore(self._session)
         self._sender = Sender(self._session, self._folders)
-        self.storage = storage or StorageSQLite()
+        self._storage = storage
+
+    @property
+    def storage(self) -> StorageABC:
+        if self._storage is None:
+            self._storage = StorageSQLite()
+        return self._storage
+
+    @storage.setter
+    def storage(self, value: StorageABC) -> None:
+        self._storage = value
 
     @staticmethod
     def _resolve(


### PR DESCRIPTION
## Summary
- Fixes #43: `Email()` constructor no longer creates `email.db` on instantiation
- `StorageSQLite` is now lazily initialized via a property, so the database file is only created when `sync()` or `restore()` actually accesses `self.storage`
- Changed `self.storage = storage or StorageSQLite()` in `__init__` to `self._storage = storage` with a `@property` that creates `StorageSQLite()` on first access

## Test plan
- [x] All 149 existing tests pass (`pytest tests/ -x -q`)
- [ ] Verify that constructing `Email(...)` without calling `sync()`/`restore()` does not create `email.db`
- [ ] Verify that calling `sync()` or `restore()` still works and creates the database as expected