### PR TITLE
Split validate_status into validate and check for clarity

### DIFF
--- a/email_profile/core/status.py
+++ b/email_profile/core/status.py
@@ -64,13 +64,21 @@ class Status:
     }
 
     @staticmethod
+    def check_status(
+        status: str,
+    ) -> StatusResponse:
+        """Return a StatusResponse without raising on failure."""
+        ok, message = Status._MESSAGES.get(status, (False, "Unknown error"))
+        return StatusResponse(ok=ok, message=message)
+
+    @staticmethod
     def validate_status(
         status: str,
-        raise_error: bool = True,
         payload: object = None,
     ) -> StatusResponse:
+        """Return a StatusResponse, raising on failure."""
         ok, message = Status._MESSAGES.get(status, (False, "Unknown error"))
-        if raise_error and not ok:
+        if not ok:
             specific = _classify(payload)
             if specific is not None:
                 raise specific

--- a/tests/core/test_status.py
+++ b/tests/core/test_status.py
@@ -22,8 +22,8 @@ class TestStatus(TestCase):
         with self.assertRaises(IMAPError):
             Status.validate_status("XYZ")
 
-    def test_validate_status_no_raise_returns_response(self):
-        response = Status.validate_status("NO", raise_error=False)
+    def test_check_status_no_returns_response(self):
+        response = Status.check_status("NO")
         self.assertFalse(response.ok)
 
 


### PR DESCRIPTION
## Summary
- Removed the confusing `raise_error` parameter from `validate_status()` — it now always raises on error (the common case)
- Added a new `check_status()` method that returns a `StatusResponse` without raising, for callers that need to inspect the result
- Updated the test that used `raise_error=False` to use `check_status()` instead

Closes #39

## Test plan
- [x] All 149 existing tests pass
- [x] Pre-commit hooks (ruff lint/format) pass