### PR TITLE
🪲 BUG-#64: Honor port and ssl flag in ImapClient.connect

### DIFF
--- a/email_profile/clients/imap/client.py
+++ b/email_profile/clients/imap/client.py
@@ -27,7 +27,7 @@ class ImapClient:
         self.password = password
         self.port = port
         self.ssl = ssl
-        self.client: Optional[imaplib.IMAP4_SSL] = None
+        self.client: Optional[imaplib.IMAP4] = None
         self.mailboxes: dict[str, MailBox] = {}
 
     @property
@@ -36,7 +36,10 @@ class ImapClient:
 
     def connect(self) -> ImapClient:
         try:
-            client = imaplib.IMAP4_SSL(self.server)
+            if self.ssl:
+                client = imaplib.IMAP4_SSL(self.server, self.port)
+            else:
+                client = imaplib.IMAP4(self.server, self.port)
             client.login(user=self.user, password=self.password)
         except Exception as error:
             raise ConnectionFailure() from error

--- a/tests/clients/imap/test_connect.py
+++ b/tests/clients/imap/test_connect.py
@@ -1,0 +1,49 @@
+"""Tests for ImapClient.connect honoring port and ssl flag."""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from email_profile.clients.imap.client import ImapClient
+
+
+class TestImapClientConnect(TestCase):
+    def _fake_client(self) -> MagicMock:
+        client = MagicMock()
+        client.list.return_value = ("OK", [])
+        return client
+
+    def test_ssl_true_uses_imap4_ssl_with_port(self):
+        fake = self._fake_client()
+        with (
+            patch("imaplib.IMAP4_SSL", return_value=fake) as ssl_cls,
+            patch("imaplib.IMAP4") as plain_cls,
+        ):
+            ImapClient(
+                server="mail.x", user="u", password="p", port=993, ssl=True
+            ).connect()
+            ssl_cls.assert_called_once_with("mail.x", 993)
+            plain_cls.assert_not_called()
+
+    def test_ssl_false_uses_imap4_with_port(self):
+        fake = self._fake_client()
+        with (
+            patch("imaplib.IMAP4_SSL") as ssl_cls,
+            patch("imaplib.IMAP4", return_value=fake) as plain_cls,
+        ):
+            ImapClient(
+                server="127.0.0.1",
+                user="u",
+                password="p",
+                port=1143,
+                ssl=False,
+            ).connect()
+            plain_cls.assert_called_once_with("127.0.0.1", 1143)
+            ssl_cls.assert_not_called()
+
+    def test_custom_ssl_port_passed_through(self):
+        fake = self._fake_client()
+        with patch("imaplib.IMAP4_SSL", return_value=fake) as ssl_cls:
+            ImapClient(
+                server="mail.x", user="u", password="p", port=9993, ssl=True
+            ).connect()
+            ssl_cls.assert_called_once_with("mail.x", 9993)


### PR DESCRIPTION
## Summary
- `ImapClient.connect()` now uses `self.port` and switches between `imaplib.IMAP4_SSL` and `imaplib.IMAP4` based on `self.ssl`
- Unblocks providers like ProtonMail Bridge (`127.0.0.1:1143`, ssl=False) and IMAP over STARTTLS on port 143
- Tests assert correct class + port for ssl=True, ssl=False, and custom SSL ports

Closes #64

## Test plan
- [x] `pytest tests/clients/imap/test_connect.py` — 3 passed