### PR TITLE
🪲 BUG-#66: Group multi-clause operands of OR/NOT in IMAP query

### DIFF
--- a/email_profile/clients/imap/query.py
+++ b/email_profile/clients/imap/query.py
@@ -25,6 +25,38 @@ def _imap_date(value: date) -> str:
     return value.strftime("%d-%b-%Y")
 
 
+def _is_balanced(expr: str) -> bool:
+    depth = 0
+    in_str = False
+    for ch in expr:
+        if ch == '"':
+            in_str = not in_str
+            continue
+        if in_str:
+            continue
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth < 0:
+                return False
+    return depth == 0
+
+
+def _group(expr: str) -> str:
+    """Wrap a possibly multi-clause IMAP expression as one search-key."""
+    expr = expr.strip()
+    if not expr:
+        return "ALL"
+    if (
+        expr.startswith("(")
+        and expr.endswith(")")
+        and _is_balanced(expr[1:-1])
+    ):
+        return expr
+    return f"({expr})"
+
+
 class _Expr:
     """Internal composable IMAP search expression."""
 
@@ -48,10 +80,10 @@ class _Expr:
 
     def __or__(self, other: QueryLike) -> _Expr:
         right = _to_expr(other)._expr
-        return _Expr(f"OR {self._expr} {right}".strip())
+        return _Expr(f"OR {_group(self._expr)} {_group(right)}")
 
     def __invert__(self) -> _Expr:
-        return _Expr(f"NOT {self._expr}")
+        return _Expr(f"NOT {_group(self._expr)}")
 
     def __repr__(self) -> str:
         return f"_Expr({self._expr!r})"

--- a/tests/clients/imap/test_query.py
+++ b/tests/clients/imap/test_query.py
@@ -59,3 +59,32 @@ class TestQ(TestCase):
         expr = (Query(subject="a") & Q.unseen()).mount()
         self.assertIn("(SUBJECT", expr)
         self.assertIn("(UNSEEN)", expr)
+
+
+class TestOrNotArity(TestCase):
+    def test_or_groups_multi_clause_operands(self):
+        expr = (
+            Query(subject="x", unseen=True) | Query(from_who="a@b")
+        ).mount()
+        self.assertEqual(expr, 'OR ((SUBJECT "x") (UNSEEN)) (FROM "a@b")')
+
+    def test_invert_groups_multi_clause(self):
+        expr = (~Query(subject="x", unseen=True)).mount()
+        self.assertEqual(expr, 'NOT ((SUBJECT "x") (UNSEEN))')
+
+    def test_exclude_groups_multi_clause(self):
+        expr = (
+            Query(subject="report")
+            .exclude(from_who="spam@x", unseen=True)
+            .mount()
+        )
+        self.assertIn('NOT ((FROM "spam@x") (UNSEEN))', expr)
+        self.assertIn('(SUBJECT "report")', expr)
+
+    def test_or_method_groups_multi_clause(self):
+        expr = Query(subject="a").or_(from_who="b@x", unseen=True).mount()
+        self.assertEqual(expr, 'OR (SUBJECT "a") ((FROM "b@x") (UNSEEN))')
+
+    def test_or_keeps_single_clause_unwrapped(self):
+        expr = (Q.subject("a") | Q.subject("b")).mount()
+        self.assertEqual(expr, 'OR (SUBJECT "a") (SUBJECT "b")')


### PR DESCRIPTION
## Summary
- Added `_group()` helper that wraps multi-clause IMAP search expressions in an outer parenthesis (single search-key group)
- `_Expr.__or__` and `_Expr.__invert__` now group both operands so the resulting `OR` / `NOT` arity matches the Python-level expression
- Single already-grouped clauses stay unwrapped to keep simple expressions readable
- Same fix also resolves `Query.exclude` / `Query.or_` / `Query.__or__` / `Query.__invert__` since they route through `_Expr`

Closes #66
Closes #72

## Test plan
- [x] `pytest tests/clients/imap/test_query.py` — 16 passed