### PR TITLE
🪲 BUG-#67: Use UID EXPUNGE in MailBox.move fallback and narrow except

### DIFF
--- a/email_profile/clients/imap/mailbox.py
+++ b/email_profile/clients/imap/mailbox.py
@@ -184,17 +184,27 @@ class MailBox:
     def move(self, target: UIDLike, destination: str) -> None:
         """Move a message into another mailbox.
 
-        Prefers ``UID MOVE`` (RFC 6851). Falls back to copy + delete + expunge
-        when the server does not advertise the MOVE extension.
+        Prefers ``UID MOVE`` (RFC 6851). Falls back to copy + delete +
+        ``UID EXPUNGE`` (RFC 4315) when the server does not advertise MOVE.
+        Only ``imaplib.IMAP4.error`` is treated as the missing-MOVE signal —
+        network/auth/quota errors propagate.
         """
+        from email_profile.core.errors import IMAPError
+
         Status.state(self._client.select(_quote(self.name)))
         uid = _uid_of(target)
         try:
             Status.state(self._client.uid("MOVE", uid, destination))
-        except Exception:
+        except imaplib.IMAP4.error:
             Status.state(self._client.uid("COPY", uid, destination))
             Status.state(self._client.uid("STORE", uid, "+FLAGS", "\\Deleted"))
-            Status.state(self._client.expunge())
+            try:
+                Status.state(self._client.uid("EXPUNGE", uid))
+            except imaplib.IMAP4.error as exc:
+                raise IMAPError(
+                    "Server lacks MOVE and UIDPLUS; message was copied and "
+                    "flagged \\Deleted but not expunged."
+                ) from exc
 
     def create(self) -> None:
         """Create this mailbox on the server."""

--- a/email_profile/clients/imap/mailbox.py
+++ b/email_profile/clients/imap/mailbox.py
@@ -186,8 +186,9 @@ class MailBox:
 
         Prefers ``UID MOVE`` (RFC 6851). Falls back to copy + delete +
         ``UID EXPUNGE`` (RFC 4315) when the server does not advertise MOVE.
-        Only ``imaplib.IMAP4.error`` is treated as the missing-MOVE signal —
-        network/auth/quota errors propagate.
+        ``imaplib.IMAP4.error`` and ``IMAPError`` (raised by ``Status.state``
+        on tagged ``NO``/``BAD`` responses) are treated as the missing-MOVE
+        signal — network/auth/quota errors propagate.
         """
         from email_profile.core.errors import IMAPError
 
@@ -195,12 +196,12 @@ class MailBox:
         uid = _uid_of(target)
         try:
             Status.state(self._client.uid("MOVE", uid, destination))
-        except imaplib.IMAP4.error:
+        except (imaplib.IMAP4.error, IMAPError):
             Status.state(self._client.uid("COPY", uid, destination))
             Status.state(self._client.uid("STORE", uid, "+FLAGS", "\\Deleted"))
             try:
                 Status.state(self._client.uid("EXPUNGE", uid))
-            except imaplib.IMAP4.error as exc:
+            except (imaplib.IMAP4.error, IMAPError) as exc:
                 raise IMAPError(
                     "Server lacks MOVE and UIDPLUS; message was copied and "
                     "flagged \\Deleted but not expunged."

--- a/tests/clients/imap/test_mailbox.py
+++ b/tests/clients/imap/test_mailbox.py
@@ -136,3 +136,39 @@ class TestMailBoxMove(TestCase):
         self.fake.uid.side_effect = side
         with self.assertRaises(IMAPError):
             self.app.inbox.move("42", "Archive")
+
+    def test_falls_back_when_server_responds_no_to_move(self):
+        """Server signals missing MOVE via tagged ``NO`` — not an exception.
+
+        ``Status.state`` translates ``("NO", ...)`` into ``IMAPError``;
+        the fallback must catch it so the COPY+STORE+UID EXPUNGE path runs.
+        """
+
+        def side(command, *args):
+            cmd = command.upper()
+            if cmd == "MOVE":
+                return ("NO", [b"MOVE not supported"])
+            return ("OK", [b"Done"])
+
+        self.fake.uid.side_effect = side
+        self.app.inbox.move("42", "Archive")
+        calls = [c.args[0] for c in self.fake.uid.call_args_list]
+        self.assertIn("COPY", calls)
+        self.assertIn("STORE", calls)
+        self.assertIn("EXPUNGE", calls)
+        self.fake.expunge.assert_not_called()
+
+    def test_raises_when_server_responds_no_to_uid_expunge(self):
+        """Server lacks UIDPLUS and replies ``NO`` to UID EXPUNGE."""
+
+        def side(command, *args):
+            cmd = command.upper()
+            if cmd == "MOVE":
+                return ("NO", [b"MOVE not supported"])
+            if cmd == "EXPUNGE":
+                return ("NO", [b"UIDPLUS not supported"])
+            return ("OK", [b"Done"])
+
+        self.fake.uid.side_effect = side
+        with self.assertRaises(IMAPError):
+            self.app.inbox.move("42", "Archive")

--- a/tests/clients/imap/test_mailbox.py
+++ b/tests/clients/imap/test_mailbox.py
@@ -1,7 +1,9 @@
+import imaplib
 from unittest import TestCase
 from unittest.mock import patch
 
 from email_profile import Email, Message, Q, Query
+from email_profile.core.errors import IMAPError
 from tests.conftest import SAMPLE_RFC822, make_fake_client
 
 
@@ -81,3 +83,56 @@ class TestMailBoxAppend(TestCase):
     def test_returns_none_without_uidplus(self):
         self.fake.append.return_value = ("OK", [b"APPEND completed"])
         self.assertIsNone(self.app.inbox.append(SAMPLE_RFC822))
+
+
+class TestMailBoxMove(TestCase):
+    def setUp(self):
+        self.fake = make_fake_client()
+        self._patcher = patch(
+            "email_profile.clients.imap.client.imaplib.IMAP4_SSL",
+            return_value=self.fake,
+        )
+        self._patcher.start()
+        self.app = Email("imap.x", "u", "p").connect()
+
+    def tearDown(self):
+        self.app.close()
+        self._patcher.stop()
+
+    def test_uses_move_when_supported(self):
+        self.app.inbox.move("42", "Archive")
+        calls = [c.args[0] for c in self.fake.uid.call_args_list]
+        self.assertIn("MOVE", calls)
+        self.assertNotIn("COPY", calls)
+        self.fake.expunge.assert_not_called()
+
+    def test_falls_back_to_copy_uid_expunge(self):
+        def side(command, *args):
+            cmd = command.upper()
+            if cmd == "MOVE":
+                raise imaplib.IMAP4.error("MOVE not supported")
+            return ("OK", [b"Done"])
+
+        self.fake.uid.side_effect = side
+        self.app.inbox.move("42", "Archive")
+        calls = [c.args[0] for c in self.fake.uid.call_args_list]
+        self.assertIn("COPY", calls)
+        self.assertIn("STORE", calls)
+        self.assertIn("EXPUNGE", calls)
+        self.fake.expunge.assert_not_called()
+
+    def test_propagates_non_imap_errors(self):
+        self.fake.uid.side_effect = ConnectionResetError("network drop")
+        with self.assertRaises(ConnectionResetError):
+            self.app.inbox.move("42", "Archive")
+
+    def test_raises_when_uidplus_missing(self):
+        def side(command, *args):
+            cmd = command.upper()
+            if cmd in {"MOVE", "EXPUNGE"}:
+                raise imaplib.IMAP4.error("not supported")
+            return ("OK", [b"Done"])
+
+        self.fake.uid.side_effect = side
+        with self.assertRaises(IMAPError):
+            self.app.inbox.move("42", "Archive")

--- a/tests/clients/imap/test_write_ops.py
+++ b/tests/clients/imap/test_write_ops.py
@@ -79,12 +79,14 @@ class TestCopyMove(_WriteTest):
         self.assertEqual(call.args, ("MOVE", "42", "Archive"))
 
     def test_move_falls_back_to_copy_delete(self):
+        import imaplib
+
         calls = []
 
         def fake_uid(command, *args):
             calls.append((command, args))
             if command.upper() == "MOVE":
-                raise Exception("MOVE not supported")
+                raise imaplib.IMAP4.error("MOVE not supported")
             return ("OK", [b"Done"])
 
         self.fake.uid.side_effect = fake_uid
@@ -94,7 +96,8 @@ class TestCopyMove(_WriteTest):
         self.assertIn("MOVE", commands)
         self.assertIn("COPY", commands)
         self.assertIn("STORE", commands)
-        self.fake.expunge.assert_called_once()
+        self.assertIn("EXPUNGE", commands)
+        self.fake.expunge.assert_not_called()
 
 
 class TestMailboxAdmin(_WriteTest):


### PR DESCRIPTION
## Summary
- `MailBox.move()` no longer issues an unqualified `EXPUNGE` when the server lacks the MOVE extension — it uses `UID EXPUNGE` (RFC 4315) targeting only the moved UID
- Narrowed the bare `except Exception` to `imaplib.IMAP4.error`, so network/auth/quota errors propagate to the caller instead of being swallowed by the COPY+DELETE fallback
- When the server also lacks UIDPLUS, raise `IMAPError` so the caller can decide whether to expunge globally — never silently nuke other `\\Deleted` messages
- Updated existing `test_move_falls_back_to_copy_delete` to assert the new behavior (UID EXPUNGE, no global expunge) and added 4 new tests covering MOVE-supported path, error propagation, and the UIDPLUS-missing path

Closes #67
Closes #30

## Test plan
- [x] `pytest tests/clients/imap/test_mailbox.py tests/clients/imap/test_write_ops.py` — all passing