### PR TITLE
🪲 BUG-#68: Avoid mutating caller EmailMessage when adding From header

### DIFF
--- a/email_profile/clients/smtp/sender.py
+++ b/email_profile/clients/smtp/sender.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import copy
 import logging
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -79,6 +80,7 @@ class Sender:
     ) -> None:
         """Send a pre-built EmailMessage."""
         if not message.get("From"):
+            message = copy.deepcopy(message)
             message["From"] = self._session.user
 
         to = message.get("To", "")

--- a/tests/clients/smtp/test_send.py
+++ b/tests/clients/smtp/test_send.py
@@ -86,6 +86,31 @@ class TestSend(_SendTest):
         sent = self.smtp.send_message.call_args[0][0]
         self.assertEqual(sent["From"], "u@x.com")
 
+    def test_send_message_does_not_mutate_caller_message(self):
+        from email.message import EmailMessage
+
+        msg = EmailMessage()
+        msg["To"] = "bob@x"
+        msg["Subject"] = "t"
+        msg.set_content("body")
+
+        self.app.send_message(msg, save_to_sent=False)
+        self.assertIsNone(msg.get("From"))
+
+    def test_send_message_twice_does_not_duplicate_from(self):
+        from email.message import EmailMessage
+
+        msg = EmailMessage()
+        msg["To"] = "bob@x"
+        msg["Subject"] = "t"
+        msg.set_content("body")
+
+        self.app.send_message(msg, save_to_sent=False)
+        self.app.send_message(msg, save_to_sent=False)
+
+        sent = self.smtp.send_message.call_args[0][0]
+        self.assertEqual(sent.get_all("From"), ["u@x.com"])
+
 
 class TestReply(_SendTest):
     def test_reply_preserves_threading(self):


### PR DESCRIPTION
## Summary
- `Sender.send_message` now `deepcopy`'s the caller's `EmailMessage` before injecting the `From` header when missing
- Prevents duplicate `From:` headers on retry and silent mutation of caller-owned objects
- Tests cover both the non-mutation invariant and the two-call retry path

Closes #68

## Test plan
- [x] `pytest tests/clients/smtp/test_send.py` — 10 passed