### PR TITLE
🪲 BUG-#69: Forward port/ssl overrides through auto-discovery factories

### DIFF
--- a/email_profile/core/credentials.py
+++ b/email_profile/core/credentials.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from typing import Optional
 
 from email_profile.providers import resolve_imap_host
 
@@ -29,15 +30,25 @@ class EmailFactories:
     """Build :class:`Credentials` without the user spelling out a hostname."""
 
     @classmethod
-    def from_address(cls, address: str, password: str) -> Credentials:
-        """Auto-discover the IMAP host from the email address."""
+    def from_address(
+        cls,
+        address: str,
+        password: str,
+        *,
+        port: Optional[int] = None,
+        ssl: Optional[bool] = None,
+    ) -> Credentials:
+        """Auto-discover the IMAP host from the email address.
+
+        ``port`` and ``ssl`` override the discovered values when given.
+        """
         host = resolve_imap_host(address)
         return Credentials(
             server=host.host,
             user=address,
             password=password,
-            port=host.port,
-            ssl=host.ssl,
+            port=host.port if port is None else port,
+            ssl=host.ssl if ssl is None else ssl,
         )
 
     @classmethod
@@ -47,6 +58,9 @@ class EmailFactories:
         user_var: str = "EMAIL_USERNAME",
         password_var: str = "EMAIL_PASSWORD",
         load_dotenv: bool = True,
+        *,
+        port: Optional[int] = None,
+        ssl: Optional[bool] = None,
     ) -> Credentials:
         """Read credentials from env vars (or `.env`)."""
         if load_dotenv:
@@ -66,6 +80,12 @@ class EmailFactories:
 
         server = os.environ.get(server_var)
         if server:
-            return Credentials(server=server, user=user, password=password)
+            return Credentials(
+                server=server,
+                user=user,
+                password=password,
+                port=993 if port is None else port,
+                ssl=True if ssl is None else ssl,
+            )
 
-        return cls.from_address(user, password)
+        return cls.from_address(user, password, port=port, ssl=ssl)

--- a/email_profile/email.py
+++ b/email_profile/email.py
@@ -42,8 +42,8 @@ class Email:
         server: Optional[str] = None,
         user: Optional[str] = None,
         password: Optional[str] = None,
-        port: int = 993,
-        ssl: bool = True,
+        port: Optional[int] = None,
+        ssl: Optional[bool] = None,
         storage: Optional[StorageABC] = None,
     ) -> None:
         connection = self._resolve(server, user, password, port, ssl)
@@ -77,17 +77,21 @@ class Email:
         server: Optional[str],
         user: Optional[str],
         password: Optional[str],
-        port: int,
-        ssl: bool,
+        port: Optional[int],
+        ssl: Optional[bool],
     ) -> Credentials:
         if server is None and user is None and password is None:
-            return EmailFactories.from_env()
+            return EmailFactories.from_env(port=port, ssl=ssl)
 
         if password is None and user is not None and server and "@" in server:
-            return EmailFactories.from_address(server, user)
+            return EmailFactories.from_address(
+                server, user, port=port, ssl=ssl
+            )
 
         if server is None and user is not None and "@" in user and password:
-            return EmailFactories.from_address(user, password)
+            return EmailFactories.from_address(
+                user, password, port=port, ssl=ssl
+            )
 
         if server is None or user is None or password is None:
             raise TypeError(
@@ -97,7 +101,11 @@ class Email:
             )
 
         return Credentials(
-            server=server, user=user, password=password, port=port, ssl=ssl
+            server=server,
+            user=user,
+            password=password,
+            port=993 if port is None else port,
+            ssl=True if ssl is None else ssl,
         )
 
     @property

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -186,6 +186,31 @@ class TestPublicProperties(TestCase):
         self.assertFalse(app.is_connected)
 
 
+class TestAutoDiscoveryOverrides(TestCase):
+    def test_kwargs_override_discovered_port_and_ssl(self):
+        from email_profile.core.types import IMAPHost
+
+        with patch(
+            "email_profile.core.credentials.resolve_imap_host",
+            return_value=IMAPHost("imap.gmail.com", port=993, ssl=True),
+        ):
+            app = Email("u@gmail.com", "pw", port=2143, ssl=False)
+            self.assertEqual(app.port, 2143)
+            self.assertFalse(app.ssl)
+            self.assertEqual(app.server, "imap.gmail.com")
+
+    def test_no_override_keeps_discovered_values(self):
+        from email_profile.core.types import IMAPHost
+
+        with patch(
+            "email_profile.core.credentials.resolve_imap_host",
+            return_value=IMAPHost("imap.gmail.com", port=993, ssl=True),
+        ):
+            app = Email("u@gmail.com", "pw")
+            self.assertEqual(app.port, 993)
+            self.assertTrue(app.ssl)
+
+
 class TestConstructorOverloads(TestCase):
     def test_three_positional_args_explicit(self):
         app = Email("imap.x.com", "u", "pw")


### PR DESCRIPTION
## Summary
- `Email(port=..., ssl=...)` kwargs are now forwarded through `EmailFactories.from_address` and `EmailFactories.from_env`, so they override the values returned by `resolve_imap_host`
- Switched `port`/`ssl` defaults to `Optional` sentinel (`None`) on both `Email.__init__` and the factories — distinguishes "user passed default" from "user did not pass anything"
- Tests cover: override applied, omission keeps discovered values

Closes #69

## Test plan
- [x] `pytest tests/test_email.py` — 29 passed