### PR TITLE
🪲 BUG-#65: Store raw RFC822 source as bytes for binary-safe backup/restore

### DIFF
--- a/email_profile/clients/imap/mailbox.py
+++ b/email_profile/clients/imap/mailbox.py
@@ -119,13 +119,13 @@ class MailBox:
         from email_profile.serializers.email import Message
 
         if isinstance(message, Message):
-            raw = message.file.encode("utf-8")
+            raw = message.file
             if date is None:
                 date = message.date
         elif isinstance(message, str):
             raw = message.encode("utf-8")
-        elif isinstance(message, bytes):
-            raw = message
+        elif isinstance(message, (bytes, bytearray)):
+            raw = bytes(message)
         else:
             raise TypeError(
                 "append expects Message, bytes or str — "

--- a/email_profile/clients/imap/sync.py
+++ b/email_profile/clients/imap/sync.py
@@ -192,7 +192,7 @@ class Sync:
                 uid=entry.uid,
                 mailbox=mailbox.name,
                 flags=entry.flags,
-                file=entry.text(),
+                file=entry.raw(),
             )
 
             try:

--- a/email_profile/models/raw.py
+++ b/email_profile/models/raw.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from sqlalchemy import Column, String, Text, UniqueConstraint
+from sqlalchemy import Column, LargeBinary, String, UniqueConstraint
 
 from email_profile.storage.db import Base
 
 
 class RawModel(Base):
-    """Complete RFC822 source (with attachments in base64)."""
+    """Complete RFC822 source stored verbatim as bytes."""
 
     __tablename__ = "raw"
     __table_args__ = (
@@ -19,4 +19,4 @@ class RawModel(Base):
     mailbox = Column(String, primary_key=True)
     message_id = Column(String, nullable=False, index=True)
     flags = Column(String, nullable=False, default="")
-    file = Column(Text)
+    file = Column(LargeBinary)

--- a/email_profile/serializers/email.py
+++ b/email_profile/serializers/email.py
@@ -30,7 +30,7 @@ class Message(BaseModel):
     reply_to: Optional[str] = None
 
     subject: Optional[str] = None
-    file: str
+    file: bytes
     body_text_plain: str = ""
     body_text_html: str = ""
     content_type: Optional[str] = None
@@ -66,7 +66,7 @@ class Message(BaseModel):
             bcc=parsed.bcc,
             reply_to=parsed.reply_to,
             subject=parsed.subject,
-            file=raw.decode("utf-8", errors="replace"),
+            file=raw,
             body_text_plain=parsed.body_text_plain,
             body_text_html=parsed.body_text_html,
             content_type=parsed.content_type,

--- a/email_profile/serializers/raw.py
+++ b/email_profile/serializers/raw.py
@@ -2,14 +2,36 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import Union
+
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class RawSerializer(BaseModel):
-    """Minimum data contract for any storage backend."""
+    """Minimum data contract for any storage backend.
+
+    ``file`` stores the raw RFC822 bytes verbatim so binary attachments
+    and non-UTF8 bodies round-trip without loss. ``str`` input is accepted
+    for backward compatibility and encoded as latin-1 (byte-preserving).
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     message_id: str
     uid: str
     mailbox: str
     flags: str = ""
-    file: str
+    file: bytes
+
+    @field_validator("file", mode="before")
+    @classmethod
+    def _coerce_file(
+        cls, value: Union[bytes, bytearray, memoryview, str]
+    ) -> bytes:
+        if isinstance(value, (bytes, bytearray, memoryview)):
+            return bytes(value)
+        if isinstance(value, str):
+            return value.encode("latin-1", errors="replace")
+        raise TypeError(
+            f"file must be bytes or str, got {type(value).__name__}"
+        )

--- a/tests/serializers/test_eml.py
+++ b/tests/serializers/test_eml.py
@@ -21,10 +21,23 @@ class TestFromRaw(TestCase):
 class TestRawSerializer(TestCase):
     def test_creates_from_fields(self):
         raw = RawSerializer(
-            message_id="<abc@x>", uid="1", mailbox="INBOX", file="raw content"
+            message_id="<abc@x>", uid="1", mailbox="INBOX", file=b"raw content"
         )
         self.assertEqual(raw.message_id, "<abc@x>")
-        self.assertEqual(raw.file, "raw content")
+        self.assertEqual(raw.file, b"raw content")
+
+    def test_str_input_coerced_to_bytes_latin1(self):
+        raw = RawSerializer(
+            message_id="<x>", uid="1", mailbox="INBOX", file="hello"
+        )
+        self.assertEqual(raw.file, b"hello")
+
+    def test_bytes_preserved_verbatim(self):
+        payload = bytes(range(256))
+        raw = RawSerializer(
+            message_id="<x>", uid="1", mailbox="INBOX", file=payload
+        )
+        self.assertEqual(raw.file, payload)
 
 
 class TestRawModel(TestCase):

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -10,7 +10,7 @@ def _raw(
     message_id: str = "<test@x>",
     uid: str = "1",
     mailbox: str = "INBOX",
-    file_content: str = "raw content",
+    file_content: bytes = b"raw content",
 ) -> RawSerializer:
     return RawSerializer(
         message_id=message_id, uid=uid, mailbox=mailbox, file=file_content
@@ -47,17 +47,23 @@ class TestStorageRaw(TestCase):
         result = self.storage.get("<test@x>")
         self.assertIsNotNone(result)
         self.assertEqual(result.message_id, "<test@x>")
-        self.assertEqual(result.file, "raw content")
+        self.assertEqual(result.file, b"raw content")
+
+    def test_binary_payload_round_trips_verbatim(self):
+        payload = bytes(range(256))
+        self.storage.save(_raw("<bin@x>", file_content=payload))
+        result = self.storage.get("<bin@x>")
+        self.assertEqual(result.file, payload)
 
     def test_get_returns_none_for_missing(self):
         result = self.storage.get("nonexistent")
         self.assertIsNone(result)
 
     def test_save_upserts(self):
-        self.storage.save(_raw("<x@x>", file_content="v1"))
-        self.storage.save(_raw("<x@x>", file_content="v2"))
+        self.storage.save(_raw("<x@x>", file_content=b"v1"))
+        self.storage.save(_raw("<x@x>", file_content=b"v2"))
         result = self.storage.get("<x@x>")
-        self.assertEqual(result.file, "v2")
+        self.assertEqual(result.file, b"v2")
 
     def test_ids(self):
         self.storage.save(_raw("<a@x>"))


### PR DESCRIPTION
## Summary
Stop lossy UTF-8 round-tripping of RFC822 source. Backup/restore now preserves binary attachments and non-UTF8 bodies byte-for-byte.

### Changes
- `RawSerializer.file` is now `bytes` (was `str`). A `field_validator` coerces incoming `str` via latin-1 (byte-preserving) for backward compatibility with any caller still passing strings
- `RawModel.file` switches `Text` → `LargeBinary` (BLOB) so SQLite stores the bytes verbatim
- `Message.file` follows suit (`bytes`), and `Message.from_raw` stores `raw` directly without `.decode("utf-8", errors='replace')`
- `Sync.orchestrate` writes `entry.raw()` instead of `entry.text()`
- `MailBox.append` receives bytes from `Message.file` unchanged (no more `.encode("utf-8")`)
- Tests cover binary round-trip across all 256 byte values, str-input coercion, and upsert with bytes

### Migration
Existing rows stored as Text are still readable by SQLite; SQLAlchemy decodes the legacy column. New writes use the bytes path. If a consumer needs to migrate historical rows, `re.encode("latin-1")` on the stored string round-trips any byte sequence — but no automatic migration is shipped since the schema change is forward-compatible.

Closes #65

## Test plan
- [x] `pytest` — 211 passed (was 208 + 3 new bytes tests)
- [x] `bytes(range(256))` round-trips through `save` → `get`